### PR TITLE
Drop PHP 8.2 support, require PHP 8.3+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: ['8.2', '8.3', '8.4']
+        php-version: ['8.3', '8.4']
 
     name: PHP ${{ matrix.php-version }}
 

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ The monotonic guard ensures timestamps never go backward and strictly increment 
 
 ## Requirements
 
-- PHP >= 8.2
+- PHP >= 8.3
 - No external dependencies
 
 ## License

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": ">=8.2"
+        "php": ">=8.3"
     },
     "require-dev": {
         "phpunit/phpunit": "^11.0"


### PR DESCRIPTION
## Summary

- Update `composer.json` to require `php >= 8.3`
- Remove PHP 8.2 from CI matrix
- Update README requirements

PHP 8.2 active support ended 31 Dec 2024. It only receives security fixes until Dec 2026. The codebase uses typed constants (`private const string`) which require PHP 8.3+.

Closes #12

## Test plan

- [x] CI should pass on PHP 8.3 and 8.4