### PR TITLE
Add Packagist auto-update via GitHub Actions

### DIFF
--- a/.github/workflows/packagist.yml
+++ b/.github/workflows/packagist.yml
@@ -1,0 +1,17 @@
+name: Update Packagist
+
+on:
+  push:
+    branches: [main]
+    tags: ['*']
+
+jobs:
+  packagist:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Packagist
+        run: |
+          curl -s -X POST "https://packagist.org/api/update-package" \
+            -d '{"repository":{"url":"https://github.com/alesitom/hybridId_package"}}' \
+            -H "Content-Type: application/json" \
+            -u "${{ secrets.PACKAGIST_USERNAME }}:${{ secrets.PACKAGIST_TOKEN }}"


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/packagist.yml` that notifies Packagist on push to main and on new tags
- Uses GitHub Secrets for authentication (no token or username exposed)

Closes #14

## Setup required

Add these secrets in repo Settings > Secrets > Actions:
- `PACKAGIST_USERNAME` = your Packagist username
- `PACKAGIST_TOKEN` = your Packagist API token

Then remove the manual webhook from Settings > Webhooks.

## Test plan

- [x] Workflow triggers on push to main and tags
- [ ] Verify Packagist updates after merge + tag