### PR TITLE
Harden CI, config, and input validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -16,16 +19,19 @@ jobs:
     name: PHP ${{ matrix.php-version }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@d59004228537ca90c8dca680592a08a675bf52b6 # v2
         with:
           php-version: ${{ matrix.php-version }}
           coverage: none
 
       - name: Install dependencies
         run: composer install --no-interaction --prefer-dist
+
+      - name: Audit dependencies
+        run: composer audit
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/.github/workflows/packagist.yml
+++ b/.github/workflows/packagist.yml
@@ -3,15 +3,20 @@ name: Update Packagist
 on:
   push:
     branches: [main]
-    tags: ['*']
+    tags: ['v*.*.*']
+
+permissions: {}
 
 jobs:
   packagist:
     runs-on: ubuntu-latest
     steps:
       - name: Notify Packagist
+        env:
+          PACKAGIST_USERNAME: ${{ secrets.PACKAGIST_USERNAME }}
+          PACKAGIST_TOKEN: ${{ secrets.PACKAGIST_TOKEN }}
         run: |
           curl -s -X POST "https://packagist.org/api/update-package" \
             -d '{"repository":{"url":"https://github.com/alesitom/hybridId_package"}}' \
             -H "Content-Type: application/json" \
-            -u "${{ secrets.PACKAGIST_USERNAME }}:${{ secrets.PACKAGIST_TOKEN }}"
+            -u "${PACKAGIST_USERNAME}:${PACKAGIST_TOKEN}"

--- a/bin/hybrid-id
+++ b/bin/hybrid-id
@@ -192,7 +192,7 @@ function commandHelp(?string $unknown = null): void
 
 function sanitize(string $input): string
 {
-    return preg_replace('/[\x00-\x1f\x7f]/', '', $input);
+    return preg_replace('/[\x00-\x1f\x7f-\x9f]/', '', $input);
 }
 
 function error(string $message): string


### PR DESCRIPTION
## Summary

- **CI hardening** (#16, #17, #18): Add `permissions` blocks, pin GitHub Actions to commit SHAs, add `composer audit` step
- **Packagist workflow** (#16, #17): Add `permissions: {}`, move secrets to env vars, restrict tag filter to semver
- **HybridId optimizations** (#19, #20, #21): O(1) profile detection via `LENGTH_TO_PROFILE` map, `getenv()` with `local_only` parameter, standardized error messages listing valid options
- **CLI sanitization** (#22): Expand `sanitize()` regex to strip C1 control characters (`\x7f-\x9f`)
- **Test coverage** (#24): Add 10 adversarial tests — path traversal in env profile, XSS in env node, oversized node, null bytes, unicode, empty/single-char node, null profile/entropy defaults

Closes #16, #17, #18, #19, #20, #21, #22, #23, #24

## Test plan

- [x] All 47 tests pass (10 new tests added)
- [ ] CI pipeline passes on PHP 8.3 and 8.4
- [ ] Verify `composer audit` step runs in CI