### PR TITLE
Refine sanitization, monotonic guard, and CI reliability

### DIFF
--- a/.github/workflows/packagist.yml
+++ b/.github/workflows/packagist.yml
@@ -16,7 +16,7 @@ jobs:
           PACKAGIST_USERNAME: ${{ secrets.PACKAGIST_USERNAME }}
           PACKAGIST_TOKEN: ${{ secrets.PACKAGIST_TOKEN }}
         run: |
-          curl -s -X POST "https://packagist.org/api/update-package" \
-            -d '{"repository":{"url":"https://github.com/alesitom/hybridId_package"}}' \
+          curl --fail-with-body -s -X POST "https://packagist.org/api/update-package" \
+            -d "{\"repository\":{\"url\":\"https://github.com/${{ github.repository }}\"}}" \
             -H "Content-Type: application/json" \
             -u "${PACKAGIST_USERNAME}:${PACKAGIST_TOKEN}"

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ The monotonic guard ensures timestamps never go backward and strictly increment 
 
 ## Requirements
 
-- PHP >= 8.3
+- PHP >= 8.3 (64-bit)
 - No external dependencies
 
 ## License

--- a/bin/hybrid-id
+++ b/bin/hybrid-id
@@ -192,7 +192,7 @@ function commandHelp(?string $unknown = null): void
 
 function sanitize(string $input): string
 {
-    return preg_replace('/[\x00-\x1f\x7f-\x9f]/', '', $input);
+    return preg_replace('/[^\x20-\x7e]/', '', $input);
 }
 
 function error(string $message): string


### PR DESCRIPTION
## Summary

**Medium:**
- **CLI sanitize()** (#26): Switch from blocklist to printable ASCII allowlist (`/[^\x20-\x7e]/`)
- **Packagist workflow** (#27, #33): Add `--fail-with-body` to curl for visible failures, use `github.repository` instead of hardcoded URL
- **Monotonic guard** (#28): Move `lastTimestamp` assignment after successful generation to prevent counter desync on failure

**Low:**
- **profiles()** (#29): Hardcode return value for guaranteed `list<string>` type and no unnecessary array operation
- **encodeBase62()** (#30): Collect chars in array + reverse once instead of prepending strings in loop
- **extractDateTime()** (#31): Include timestamp value in error message for debuggability
- **compact() docblock** (#32): Add `@note` warning about multi-node collision risk

**Info:**
- **64-bit check** (#34): Runtime `PHP_INT_SIZE` check in `generateWithProfile()` and documented in README

Closes #26, #27, #28, #29, #30, #31, #32, #33, #34

## Test plan

- [x] All 47 tests pass locally
- [x] CI passes on PHP 8.3 and 8.4