### PR TITLE
Fix Packagist auth method

### DIFF
--- a/.github/workflows/packagist.yml
+++ b/.github/workflows/packagist.yml
@@ -17,7 +17,7 @@ jobs:
           PACKAGIST_TOKEN: ${{ secrets.PACKAGIST_TOKEN }}
           REPO_URL: https://github.com/${{ github.repository }}
         run: |
-          curl --fail-with-body -s -X POST "https://packagist.org/api/update-package" \
+          curl --fail-with-body -s -X POST \
+            "https://packagist.org/api/update-package?username=${PACKAGIST_USERNAME}&apiToken=${PACKAGIST_TOKEN}" \
             -d "{\"repository\":{\"url\":\"${REPO_URL}\"}}" \
-            -H "Content-Type: application/json" \
-            -u "${PACKAGIST_USERNAME}:${PACKAGIST_TOKEN}"
+            -H "Content-Type: application/json"


### PR DESCRIPTION
## Summary

Packagist API expects `username` and `apiToken` as query parameters, not HTTP Basic Auth (`-u`). This was the cause of the "Missing or invalid username/apiToken" error on every tag push.

## Test plan

- [ ] Merge and push a tag to verify Packagist workflow succeeds