### PR TITLE
Add compare() for chronological sorting

### DIFF
--- a/src/HybridIdGenerator.php
+++ b/src/HybridIdGenerator.php
@@ -281,6 +281,17 @@ final class HybridIdGenerator implements IdGenerator
         return array_keys(self::PROFILES);
     }
 
+    /**
+     * Compare two HybridIds chronologically.
+     *
+     * Returns -1, 0, or 1 — compatible with usort() and spaceship operator convention.
+     * Handles prefixed IDs by stripping prefixes before comparison.
+     */
+    public static function compare(string $a, string $b): int
+    {
+        return self::extractTimestamp($a) <=> self::extractTimestamp($b);
+    }
+
     // -------------------------------------------------------------------------
     // Internal
     // -------------------------------------------------------------------------

--- a/tests/HybridIdGeneratorTest.php
+++ b/tests/HybridIdGeneratorTest.php
@@ -729,6 +729,56 @@ final class HybridIdGeneratorTest extends TestCase
     }
 
     // -------------------------------------------------------------------------
+    // Compare
+    // -------------------------------------------------------------------------
+
+    public function testCompareReturnsCorrectOrder(): void
+    {
+        $gen = new HybridIdGenerator();
+        $id1 = $gen->generate();
+        usleep(2000);
+        $id2 = $gen->generate();
+
+        $this->assertSame(-1, HybridIdGenerator::compare($id1, $id2));
+        $this->assertSame(1, HybridIdGenerator::compare($id2, $id1));
+    }
+
+    public function testCompareWorksWithUsort(): void
+    {
+        $gen = new HybridIdGenerator();
+        $ids = [];
+
+        for ($i = 0; $i < 20; $i++) {
+            $ids[] = $gen->generate();
+        }
+
+        $shuffled = $ids;
+        shuffle($shuffled);
+
+        usort($shuffled, HybridIdGenerator::compare(...));
+
+        $this->assertSame($ids, $shuffled);
+    }
+
+    public function testCompareHandlesPrefixedIds(): void
+    {
+        $gen = new HybridIdGenerator();
+        $id1 = $gen->generate('usr');
+        usleep(2000);
+        $id2 = $gen->generate('ord');
+
+        $this->assertSame(-1, HybridIdGenerator::compare($id1, $id2));
+    }
+
+    public function testCompareEqualTimestampsReturnsZero(): void
+    {
+        $gen = new HybridIdGenerator();
+        $id = $gen->generate();
+
+        $this->assertSame(0, HybridIdGenerator::compare($id, $id));
+    }
+
+    // -------------------------------------------------------------------------
     // Edge cases
     // -------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Add `HybridIdGenerator::compare($a, $b)` static method
- Returns -1, 0, or 1 — compatible with `usort()` and spaceship convention
- Handles prefixed IDs transparently (strips before comparing)
- Usage: `usort($ids, HybridIdGenerator::compare(...))`

## Test plan

- [x] 73 tests passing (4 new: correct order, usort integration, prefixed IDs, equal timestamps)

Closes #51