### PR TITLE
Fix modulo bias, prefix edge case, CLI sanitization, and profile bound

### DIFF
--- a/bin/hybrid-id
+++ b/bin/hybrid-id
@@ -97,14 +97,14 @@ function commandGenerate(array $args): void
     try {
         $gen = new HybridIdGenerator(profile: $profile, node: $node);
     } catch (\InvalidArgumentException $e) {
-        die(error($e->getMessage()));
+        die(error(sanitize($e->getMessage())));
     }
 
     for ($i = 0; $i < $count; $i++) {
         try {
             echo $gen->generate($prefix) . PHP_EOL;
         } catch (\InvalidArgumentException $e) {
-            die(error($e->getMessage()));
+            die(error(sanitize($e->getMessage())));
         }
     }
 }

--- a/tests/HybridIdGeneratorTest.php
+++ b/tests/HybridIdGeneratorTest.php
@@ -640,6 +640,11 @@ final class HybridIdGeneratorTest extends TestCase
         $this->assertNull(HybridIdGenerator::extractPrefix($gen->generate()));
     }
 
+    public function testExtractPrefixReturnsNullForLeadingUnderscore(): void
+    {
+        $this->assertNull(HybridIdGenerator::extractPrefix('_ABCDEFGHIJ1234567890'));
+    }
+
     public function testPrefixValidationRejectsEmpty(): void
     {
         $gen = new HybridIdGenerator();
@@ -883,9 +888,21 @@ final class HybridIdGeneratorTest extends TestCase
     {
         try {
             $this->expectException(\InvalidArgumentException::class);
-            $this->expectExceptionMessage('at least 1');
+            $this->expectExceptionMessage('between 1 and 128');
 
             HybridIdGenerator::registerProfile('norandom', 0);
+        } finally {
+            HybridIdGenerator::resetProfiles();
+        }
+    }
+
+    public function testRegisterProfileRejectsExcessiveRandom(): void
+    {
+        try {
+            $this->expectException(\InvalidArgumentException::class);
+            $this->expectExceptionMessage('between 1 and 128');
+
+            HybridIdGenerator::registerProfile('huge', 129);
         } finally {
             HybridIdGenerator::resetProfiles();
         }


### PR DESCRIPTION
## Summary
- **#59**: Eliminate modulo bias in `randomBase62()` using rejection sampling with batched buffer (limit=248), ensuring uniform base62 distribution
- **#63**: Return `null` from `extractPrefix()` when ID starts with underscore instead of empty string
- **#64**: Apply `sanitize()` consistently to exception messages in CLI error paths for defense-in-depth
- **#62**: Add upper bound of 128 to `registerProfile()` random length to prevent excessive memory allocation

## Test plan
- [x] All 85 existing + new tests pass
- [x] New test: `testExtractPrefixReturnsNullForLeadingUnderscore`
- [x] New test: `testRegisterProfileRejectsExcessiveRandom`
- [x] Updated assertion message in `testRegisterProfileRejectsZeroRandom`

Closes #59, closes #63, closes #64, closes #62