### PR TITLE
Code quality, security hardening, and test coverage improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ HybridIdGenerator::registerProfile('tiny', 2);
 
 Constraints:
 - Profile name must be lowercase alphanumeric, starting with a letter
-- Random length must be between 1 and 128
+- Random length must be between 6 and 128
 - Total length must not conflict with an existing profile
 
 ## Interface and Dependency Injection

--- a/bin/hybrid-id
+++ b/bin/hybrid-id
@@ -164,7 +164,7 @@ function commandProfiles(): void
         $config = HybridIdGenerator::profileConfig($name);
         $entropy = HybridIdGenerator::entropy($name);
         $structure = "{$config['ts']}ts + {$config['node']}node + {$config['random']}rand";
-        $cmp = $comparisons[$name];
+        $cmp = $comparisons[$name] ?? 'custom';
 
         printf("  %-10s  %-7d  %-21s  %-12s  %s" . PHP_EOL, $name, $config['length'], $structure, "{$entropy} bits", $cmp);
     }


### PR DESCRIPTION
## Summary
- **#70**: Fix `commandProfiles()` undefined array key for custom profiles (`?? 'custom'` fallback)
- **#71**: Raise minimum random length from 1 to 6 in `registerProfile()` for parity with compact profile entropy floor (**breaking change**)
- **#72**: Remove redundant `resolveProfileByLength()` call in `registerProfile()`
- **#73**: Simplify `encodeBase62()` with string prepend instead of array+reverse+implode
- **#74**: Refactor `detectProfile()` to reuse `extractPrefix()`, eliminating duplicated prefix extraction logic
- **#75**: Add cross-profile `compare()` tests (compact vs extended, with and without prefixes)
- **#76**: Document CRC32 modulo bias (~0.00018%) in `autoDetectNode()` inline comment

## Breaking Change
`registerProfile()` now requires `random >= 6` (was 1). Custom profiles with random 1-5 are no longer accepted. Built-in profiles are not affected.

## Test plan
- [x] 88 tests, 429 assertions pass
- [x] New: `testRegisterProfileRejectsInsufficientRandom` (boundary at 5)
- [x] New: `testCompareAcrossProfiles` (compact vs extended)
- [x] New: `testCompareAcrossProfilesWithPrefixes`
- [x] New edge cases: double underscore, embedded underscore in prefix validation
- [x] Updated: `testCustomProfileConfig` (random 2→8), error message assertions (6 and 128)

Closes #70, closes #71, closes #72, closes #73, closes #74, closes #75, closes #76