### PR TITLE
Fix CLI input validation, error handling, and docs (#95-#98)

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,8 +285,8 @@ strlen($id);                                    // 36 (3 prefix + 1 underscore +
 HybridIdGenerator::detectProfile($id);          // "ultra"
 HybridIdGenerator::entropy('ultra');             // 130.9
 
-// Register a minimal 12-char profile: 8ts + 2node + 2random
-HybridIdGenerator::registerProfile('tiny', 2);
+// Register an 18-char profile: 8ts + 2node + 8random
+HybridIdGenerator::registerProfile('tiny', 8);
 ```
 
 Constraints:

--- a/src/Cli/Application.php
+++ b/src/Cli/Application.php
@@ -80,11 +80,12 @@ final class Application
                     $prefix = $args[++$i];
                     break;
                 default:
-                    if (str_starts_with($args[$i], '-')) {
-                        $this->output->error('Unknown option: ' . self::sanitize($args[$i]));
-                        return 1;
-                    }
-                    break;
+                    $this->output->error(
+                        str_starts_with($args[$i], '-')
+                            ? 'Unknown option: ' . self::sanitize($args[$i])
+                            : 'Unexpected argument: ' . self::sanitize($args[$i]),
+                    );
+                    return 1;
             }
         }
 
@@ -107,7 +108,7 @@ final class Application
         for ($i = 0; $i < $count; $i++) {
             try {
                 $this->output->writeln($gen->generate($prefix));
-            } catch (\InvalidArgumentException $e) {
+            } catch (\Throwable $e) {
                 $this->output->error(self::sanitize($e->getMessage()));
                 return 1;
             }
@@ -125,11 +126,10 @@ final class Application
             return 1;
         }
 
-        $id = self::sanitize($id);
         $profile = HybridIdGenerator::detectProfile($id);
 
         if ($profile === null) {
-            $this->output->error('Invalid HybridId: ' . $id);
+            $this->output->error('Invalid HybridId: ' . self::sanitize($id));
             return 1;
         }
 

--- a/src/HybridIdGenerator.php
+++ b/src/HybridIdGenerator.php
@@ -276,7 +276,7 @@ final class HybridIdGenerator implements IdGenerator
      * Returns an array with 'valid' => true and all components for valid IDs,
      * or 'valid' => false with partial data for invalid IDs.
      *
-     * @return array{valid: bool, prefix: ?string, profile?: string, body?: string, timestamp?: int, datetime?: \DateTimeImmutable, node?: string, random?: string}
+     * @return array{valid: bool, prefix: ?string, body: ?string, profile?: string, timestamp?: int, datetime?: ?\DateTimeImmutable, node?: string, random?: string}
      */
     public static function parse(string $id): array
     {

--- a/tests/Cli/ApplicationTest.php
+++ b/tests/Cli/ApplicationTest.php
@@ -188,6 +188,17 @@ final class ApplicationTest extends TestCase
         $this->assertStringContainsString('Unknown option', $output->getErrors()[0]);
     }
 
+    public function testGenerateRejectsUnexpectedPositionalArg(): void
+    {
+        $output = new BufferedOutput();
+        $app = new Application($output);
+
+        $exitCode = $app->run(['hybrid-id', 'generate', 'unexpected-arg']);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertStringContainsString('Unexpected argument', $output->getErrors()[0]);
+    }
+
     public function testGenerateRejectsInvalidPrefix(): void
     {
         $output = new BufferedOutput();
@@ -236,6 +247,20 @@ final class ApplicationTest extends TestCase
         $text = $output->getOutput();
         $this->assertStringContainsString('ID:', $text);
         $this->assertStringNotContainsString('Prefix:', $text);
+    }
+
+    public function testInspectRejectsValidIdWithNullByte(): void
+    {
+        $gen = new HybridIdGenerator();
+        $validId = $gen->generate();
+
+        $output = new BufferedOutput();
+        $app = new Application($output);
+
+        $exitCode = $app->run(['hybrid-id', 'inspect', $validId . "\x00"]);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertStringContainsString('Invalid HybridId', $output->getErrors()[0]);
     }
 
     public function testInspectInvalidIdReturnsError(): void


### PR DESCRIPTION
## Summary

- **#95**: Validate raw input in `inspect` before sanitizing — a valid ID + `\x00` was silently accepted as valid
- **#96**: Reject unexpected positional arguments in `generate` — `hybrid-id generate foo` now fails instead of silently ignoring
- **#97**: Broaden generation catch to `\Throwable` — covers `random_bytes()` entropy failures
- **#98**: Fix README `registerProfile('tiny', 2)` example — random length minimum is 6
- Fix `parse()` PHPDoc return type to match actual nullability (`body: ?string`, `datetime?: ?\DateTimeImmutable`)

## Test plan

- [x] 152 tests, 588 assertions — all green
- [x] New test: inspect rejects valid ID with null byte appended
- [x] New test: generate rejects unexpected positional arguments

Closes #95, closes #96, closes #97, closes #98