### PR TITLE
Add PHP 8.5 to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: ['8.3', '8.4']
+        php-version: ['8.3', '8.4', '8.5']
 
     name: PHP ${{ matrix.php-version }}
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Compact, time-sortable unique ID generator for PHP. A space-efficient alternativ
 composer require alesitom/hybrid-id
 ```
 
-Requires PHP >= 8.3 (64-bit). No external dependencies.
+Requires PHP 8.3, 8.4, or 8.5 (64-bit). No external dependencies.
 
 ## Quick Start
 
@@ -686,7 +686,8 @@ class Order
 
 ## Requirements
 
-- PHP >= 8.3 (64-bit)
+- PHP 8.3, 8.4, or 8.5 (64-bit)
+- Tested on all three versions via CI
 - No external dependencies
 
 ## License


### PR DESCRIPTION
## Summary
- Add PHP 8.5 to the CI test matrix (8.3, 8.4, 8.5)
- Update README to reflect tested PHP versions

## Test plan
- [x] CI passes on all three PHP versions