### PR TITLE
chore: add /tmp/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor/
 /composer.lock
 /.phpunit.cache/
+/tmp/


### PR DESCRIPTION
## Summary
- Add `/tmp/` to `.gitignore` as a safe workspace for internal temporary files (review outputs, scratch notes, etc.)

## Test plan
- No code changes, only `.gitignore` update