### PR TITLE
fix: v4.2.0 code review findings (#191-#198)

### DIFF
--- a/src/HybridIdGenerator.php
+++ b/src/HybridIdGenerator.php
@@ -556,9 +556,14 @@ final class HybridIdGenerator implements IdGenerator
             sprintf('%d %06d', $seconds, $microseconds),
         );
 
-        // Unreachable: extractTimestamp() validates the ID and any valid
-        // millisecond timestamp produces a valid DateTime.
-        assert($dt instanceof \DateTimeImmutable);
+        if (!$dt instanceof \DateTimeImmutable) {
+            // @codeCoverageIgnoreStart — unreachable: extractTimestamp() validates
+            // the ID and any valid millisecond timestamp produces a valid DateTime.
+            throw new \RuntimeException(
+                sprintf('Failed to create DateTime from HybridId (timestamp: %d ms)', $timestampMs),
+            );
+            // @codeCoverageIgnoreEnd
+        }
 
         return $dt;
     }

--- a/src/Profile.php
+++ b/src/Profile.php
@@ -21,11 +21,7 @@ enum Profile: string
      */
     public function bodyLength(): int
     {
-        return match ($this) {
-            self::Compact => 16,
-            self::Standard => 20,
-            self::Extended => 24,
-        };
+        return HybridIdGenerator::profileConfig($this)['length'];
     }
 
     /**
@@ -33,7 +29,7 @@ enum Profile: string
      *
      * Shortcut for HybridIdGenerator::profileConfig($this).
      *
-     * @return array{length: int, node: int, random: int}
+     * @return array{length: int, ts: int, node: int, random: int}
      *
      * @since 4.2.0
      */

--- a/src/Uuid/UuidConverter.php
+++ b/src/Uuid/UuidConverter.php
@@ -276,6 +276,7 @@ final class UuidConverter
     /**
      * Decode node and random base62 strings from a parsed HybridId.
      *
+     * @param array{node: ?string, random: string} $parsed
      * @return array{int, int} [nodeValue, randomValue]
      */
     private static function decodeComponents(array $parsed): array
@@ -290,6 +291,8 @@ final class UuidConverter
      * Build a timestamp-preserving UUID (v7 or v4-format) from a HybridId.
      *
      * v7 and v4-format share identical encoding logic — only the version digit differs.
+     *
+     * @param int<1,9> $version UUID version digit
      */
     private static function buildTimestampPreservingUuid(string $hybridId, string $method, int $version): string
     {

--- a/tests/ProfileTest.php
+++ b/tests/ProfileTest.php
@@ -96,6 +96,7 @@ final class ProfileTest extends TestCase
                 $config,
             );
             $this->assertArrayHasKey('length', $config);
+            $this->assertArrayHasKey('ts', $config);
             $this->assertArrayHasKey('node', $config);
             $this->assertArrayHasKey('random', $config);
             $this->assertSame($profile->bodyLength(), $config['length']);


### PR DESCRIPTION
## Summary

Addresses all findings from the 3-agent code review (php-pro, security-auditor, code-reviewer):

- **#191** (HIGH): Replace `assert()` with `if/throw` in `extractDateTime()` — `assert` is stripped by `zend.assertions=-1` in production
- **#192** (MEDIUM): Clean up `withCallback()` sentinel pattern — single constructor with optional callback, restores `readonly`
- **#193** (MEDIUM): Add prefix-mismatch guard to callback mode — now consistent with sequential mode
- **#194** (MINOR): Fix PHPDoc return shape for `Profile::config()` — add missing `ts` key
- **#195** (MINOR): Add `@param` shape to `decodeComponents()`
- **#196** (MINOR): Add `@param int<1,9>` constraint to `buildTimestampPreservingUuid()`
- **#197** (LOW): Delegate `Profile::bodyLength()` to `profileConfig()` — single source of truth
- **#198**: Add 4 missing test cases (callback prefix mismatch, exception propagation, batch invalid count, ts key assertion)

## Test plan

- [x] All 341 tests pass (337 existing + 4 new)
- [x] CI passes on PHP 8.3, 8.4, 8.5

Closes #191, closes #192, closes #193, closes #194, closes #195, closes #196, closes #197, closes #198