### PR TITLE
docs: v4.2.0 changelog + blindSecret documentation (#189)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [4.2.0] - 2026-02-18
+
+### Added
+- `Profile::bodyLength()` and `Profile::config()` convenience methods on the enum — reduces boilerplate when working with profiles directly (#178, #185)
+- `MockHybridIdGenerator::withCallback(\Closure $callback)` factory method for dynamic ID generation in tests — no need to predict call count or order (#184)
+- Performance regression tests for `generate()`, `generateBatch()`, and `encodeBase62()`/`decodeBase62()` round-trips (#177)
+
+### Changed
+- Refactored UUID builder methods in `UuidConverter` — extracted `parseForConversion()`, `decodeComponents()`, and `buildTimestampPreservingUuid()` to eliminate duplication between `toUUIDv8/v7/v4Format` (#175)
+- `Profile::bodyLength()` delegates to `profileConfig()` for single source of truth (#197)
+- `MockHybridIdGenerator::withCallback()` uses clean constructor pattern instead of sentinel-based post-construction mutation (#192)
+
+### Fixed
+- `extractDateTime()` — replaced `assert()` with `if/throw` guard; `assert()` is stripped when `zend.assertions=-1` (common production setting), causing a confusing `TypeError` instead of a library-domain exception (#191)
+- `MockHybridIdGenerator` callback mode now enforces prefix-mismatch guard, consistent with sequential mode (#193)
+- Replaced unreachable code in `extractDateTime()` with defensive guard (#176)
+
+### Documentation
+- Documented `blindSecret` constructor parameter and `HYBRID_ID_BLIND_SECRET` env var in blind-mode.md, api-reference.md, and README (#189)
+- Fixed PHPDoc return shape for `Profile::config()` — added missing `ts` key (#194)
+- Added `@param` shape to `decodeComponents()` in `UuidConverter` (#195)
+- Added `@param int<1,9>` constraint to `buildTimestampPreservingUuid()` (#196)
+
 ## [4.1.2] - 2026-02-17
 
 ### Fixed
@@ -251,6 +274,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 - Configurable entropy profiles
 - Time-sortable IDs with millisecond precision
 
+[4.2.0]: https://github.com/alesitom/hybrid-id/compare/v4.1.2...v4.2.0
 [4.1.2]: https://github.com/alesitom/hybrid-id/compare/v4.1.1...v4.1.2
 [4.1.1]: https://github.com/alesitom/hybrid-id/compare/v4.1.0...v4.1.1
 [4.1.0]: https://github.com/alesitom/hybrid-id/compare/v4.0.0...v4.1.0

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ $gen = new HybridIdGenerator(profile: 'extended', node: 'A1');
 // Compact — no node needed
 $gen = new HybridIdGenerator(profile: 'compact');
 
-// From environment variables (HYBRID_ID_PROFILE, HYBRID_ID_NODE, HYBRID_ID_BLIND)
+// From environment variables (HYBRID_ID_PROFILE, HYBRID_ID_NODE, HYBRID_ID_BLIND, HYBRID_ID_BLIND_SECRET)
 $gen = HybridIdGenerator::fromEnv();
 ```
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -33,6 +33,25 @@ $ids = $gen->generateBatch(100, 'evt');
 
 Large batches advance the monotonic counter proportionally (e.g. 5,000 IDs = ~5s drift). Throws `IdOverflowException` if drift exceeds `MAX_DRIFT_MS` (5,000ms).
 
+### `fromEnv(?ProfileRegistryInterface $registry = null): self` (static)
+
+Construct a generator from environment variables. Useful for twelve-factor app configuration.
+
+```php
+$gen = HybridIdGenerator::fromEnv();
+```
+
+| Variable | Default | Description |
+|---|---|---|
+| `HYBRID_ID_PROFILE` | `standard` | Profile name: `compact`, `standard`, or `extended` (or any registered custom profile). |
+| `HYBRID_ID_NODE` | `null` | Two-character base62 node identifier. Required when profile uses a node field and `HYBRID_ID_REQUIRE_NODE` is not `0`. |
+| `HYBRID_ID_REQUIRE_NODE` | `1` (enabled) | Set to `0` to disable the node requirement guard. Has no effect on `compact` profile. |
+| `HYBRID_ID_BLIND` | `0` (disabled) | Set to `1` or `true` to enable blind mode. |
+| `HYBRID_ID_BLIND_SECRET` | `null` | Base64-encoded persistent HMAC secret. Decoded and passed as `blindSecret`. See [Blind Mode](blind-mode.md#persistent-secrets). |
+| `HYBRID_ID_MAX_LENGTH` | `null` | Maximum allowed ID length (positive integer). Throws `IdOverflowException` when exceeded. |
+
+Variables that are not set or are empty strings are treated as absent (the constructor default is used). Throws `\InvalidArgumentException` for malformed values.
+
 ## Validation
 
 ### `validate(string $id, ?string $expectedPrefix = null): bool` (instance)


### PR DESCRIPTION
## Summary
- Add v4.2.0 CHANGELOG entry covering all Added/Changed/Fixed/Documentation items
- Document `blindSecret` constructor parameter and `HYBRID_ID_BLIND_SECRET` env var in blind-mode.md (Persistent Secrets section)
- Add `fromEnv()` section with full env var reference table to api-reference.md
- Update README `fromEnv()` comment to include `HYBRID_ID_BLIND_SECRET`

Closes #189

## Test plan
- [ ] Verify blind-mode.md renders correctly on GitHub (code blocks, links)
- [x] Verify api-reference.md `fromEnv()` table renders correctly
- [x] Verify CHANGELOG links resolve to correct comparison URLs