### PR TITLE
fix: blindSecret bypass, fromUUID extended validation, SHA docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [4.3.0] - 2026-02-19
+
+### Fixed
+- `blindSecret` without `blind: true` now correctly activates blind mode and bypasses `requireExplicitNode` — previously `new HybridIdGenerator(blindSecret: $secret)` threw `NodeRequiredException` (#203)
+- `UuidConverter::fromUUIDv7()` and `fromUUIDv4Format()` now reject `Profile::Extended` with `InvalidProfileException`, matching the `to*` methods — previously accepted silently with truncated output (#204)
+- Documentation references to HMAC-SHA256 corrected to HMAC-SHA384 in blind-mode.md and internals.md (#205)
+
 ## [4.2.0] - 2026-02-18
 
 ### Added

--- a/docs/blind-mode.md
+++ b/docs/blind-mode.md
@@ -28,7 +28,7 @@ $gen = HybridIdGenerator::fromEnv();
 When no `blindSecret` is provided, the constructor generates a 32-byte secret via `random_bytes(32)`. When `blindSecret` is provided, that value is used as the HMAC key instead. During generation:
 
 1. Pack monotonic timestamp + node into binary
-2. HMAC-SHA256 with the per-instance secret
+2. HMAC-SHA384 with the per-instance secret
 3. Derive base62 characters from the HMAC output (replacing timestamp+node portion)
 4. Append the random portion (unchanged)
 
@@ -52,7 +52,7 @@ $secret = random_bytes(32);
 $gen = new HybridIdGenerator(node: 'A1', blind: true, blindSecret: $secret);
 ```
 
-The `blindSecret` parameter accepts a raw binary string (`?string`). The value is used directly as the HMAC-SHA256 key.
+The `blindSecret` parameter accepts a raw binary string (`?string`). The value is used directly as the HMAC-SHA384 key.
 
 ### Via environment variable
 

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -69,13 +69,14 @@ Unlike ULID or TypeID, HybridId doesn't embed a version identifier in the ID. Re
 - Profile detection works by length (16/20/24 for built-in profiles)
 - Breaking format changes get a new major version, not a new byte
 
-## Blind Mode HMAC
+## Blind Mode HMAC (SHA-384)
 
 Input: `pack('J', timestamp) . node` (big-endian 64-bit int + 2-char node).
-Key: `random_bytes(32)` generated once per instance.
-Output: `hexdec(substr(hmac_hex, 0, 15)) % (62 ^ opaqueLen)` encoded to base62.
+Key: `random_bytes(32)` generated once per instance (or persistent via `blindSecret`).
+Algorithm: `hash_hmac('sha384', input, key, binary: true)`.
+Output: per-character derivation from 16-bit pairs of HMAC bytes, each `% 62`, for `opaqueLen` characters.
 
-The `% 62^n` introduces slight modulo bias, but this is acceptable — the HMAC output is for privacy (making timestamps unextractable), not for cryptographic key material.
+The per-character `% 62` on 16-bit values introduces ~0.003% modulo bias, which is acceptable — the HMAC output is for privacy (making timestamps unextractable), not for cryptographic key material.
 
 ## Prefix Design
 

--- a/src/HybridIdGenerator.php
+++ b/src/HybridIdGenerator.php
@@ -111,7 +111,7 @@ final class HybridIdGenerator implements IdGenerator
                 throw new InvalidIdException('Node must be exactly 2 base62 characters (0-9, A-Z, a-z)');
             }
             $this->node = $node;
-        } elseif ($blind) {
+        } elseif ($this->blind) {
             // Blind mode: node is only used as HMAC input, secret differentiates instances
             $this->node = self::autoDetectNode();
         } elseif ($requireExplicitNode && $this->profileConfig['node'] > 0) {

--- a/src/Uuid/UuidConverter.php
+++ b/src/Uuid/UuidConverter.php
@@ -130,6 +130,7 @@ final class UuidConverter
         self::assertUuidFormat($uuid, 7);
 
         $profileName = $profile instanceof Profile ? $profile->value : $profile;
+        self::assertSupportedProfile($profileName, 'fromUUIDv7');
         $hex = self::stripHyphens($uuid);
 
         $timestamp = self::safeHexdec(substr($hex, 0, 12));
@@ -210,6 +211,7 @@ final class UuidConverter
         self::assertUuidFormat($uuid, 4);
 
         $profileName = $profile instanceof Profile ? $profile->value : $profile;
+        self::assertSupportedProfile($profileName, 'fromUUIDv4Format');
         $hex = self::stripHyphens($uuid);
         $config = HybridIdGenerator::profileConfig($profileName);
 

--- a/tests/BlindModeTest.php
+++ b/tests/BlindModeTest.php
@@ -122,6 +122,33 @@ final class BlindModeTest extends TestCase
         $this->assertSame(20, strlen($id));
     }
 
+    public function testBlindSecretAloneBypassesRequireExplicitNode(): void
+    {
+        // blindSecret without blind:true must imply blind mode
+        // and skip NodeRequiredException (requireExplicitNode defaults to true)
+        $gen = new HybridIdGenerator(blindSecret: random_bytes(32));
+
+        $this->assertTrue($gen->isBlind());
+        $this->assertSame(20, strlen($gen->generate()));
+    }
+
+    public function testBlindSecretAloneActivatesBlindMode(): void
+    {
+        $secret = random_bytes(32);
+        $gen = new HybridIdGenerator(blindSecret: $secret);
+
+        $this->assertTrue($gen->isBlind());
+        $this->assertTrue(HybridIdGenerator::isValid($gen->generate()));
+    }
+
+    public function testBlindSecretWithExplicitNodeWorks(): void
+    {
+        $gen = new HybridIdGenerator(node: 'A1', blindSecret: random_bytes(32));
+
+        $this->assertTrue($gen->isBlind());
+        $this->assertSame(20, strlen($gen->generate()));
+    }
+
     // -------------------------------------------------------------------------
     // Monotonic guard
     // -------------------------------------------------------------------------

--- a/tests/Uuid/UuidConverterTest.php
+++ b/tests/Uuid/UuidConverterTest.php
@@ -251,6 +251,16 @@ final class UuidConverterTest extends TestCase
         $this->assertSame($id, $recovered);
     }
 
+    public function testFromUUIDv7RejectsExtendedProfile(): void
+    {
+        $gen = new HybridIdGenerator(profile: 'standard', node: 'T1');
+        $uuid = UuidConverter::toUUIDv7($gen->generate());
+
+        $this->expectException(InvalidProfileException::class);
+
+        UuidConverter::fromUUIDv7($uuid, Profile::Extended);
+    }
+
     // =========================================================================
     // UUIDv4-format — lossy
     // =========================================================================
@@ -362,6 +372,16 @@ final class UuidConverterTest extends TestCase
         $this->expectExceptionMessage('maximum encodable');
 
         UuidConverter::fromUUIDv4Format($uuid, 'standard', 62 ** 8);
+    }
+
+    public function testFromUUIDv4FormatRejectsExtendedProfile(): void
+    {
+        $gen = new HybridIdGenerator(profile: 'standard', node: 'T1');
+        $uuid = UuidConverter::toUUIDv4Format($gen->generate());
+
+        $this->expectException(InvalidProfileException::class);
+
+        UuidConverter::fromUUIDv4Format($uuid, Profile::Extended);
     }
 
     // =========================================================================


### PR DESCRIPTION
## Summary

- **#203** (bug/high): `blindSecret` without `blind: true` now correctly activates blind mode and bypasses `requireExplicitNode` — single-word fix `$blind` → `$this->blind`
- **#204** (bug/medium): `fromUUIDv7()` and `fromUUIDv4Format()` now reject `Profile::Extended` with `InvalidProfileException`, matching the `to*` methods
- **#205** (bug/medium): Documentation corrected from HMAC-SHA256 to HMAC-SHA384 in blind-mode.md and internals.md

## Test plan

- [x] 3 new regression tests for #203 in `BlindModeTest.php`
- [x] 2 new regression tests for #204 in `UuidConverterTest.php`
- [x] PHPUnit: 353 tests, 2121 assertions
- [x] PHPStan level max: 0 errors
- [x] PHP-CS-Fixer: 0 fixes
- [x] Grep for "SHA-256" in docs: 0 remaining references

Closes #203, closes #204, closes #205