### PR TITLE
Fix various minor issues and code analysis warnings

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -31,7 +31,7 @@ $ids = $gen->generateBatch(100, 'evt');
 // ['evt_...', 'evt_...', ...] — 100 unique, ordered IDs
 ```
 
-Large batches advance the monotonic counter proportionally (e.g. 5,000 IDs = ~5s drift). Throws `IdOverflowException` if drift exceeds `MAX_DRIFT_MS` (5,000ms).
+Large batches advance the monotonic counter proportionally (e.g. 10,000 IDs = ~10s drift). Throws `IdOverflowException` if drift exceeds `MAX_DRIFT_MS` (10,000ms).
 
 ### `fromEnv(?ProfileRegistryInterface $registry = null): self` (static)
 

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -15,9 +15,9 @@ This guarantees strict ordering within an instance but introduces "drift" — th
 
 ### Drift cap
 
-`MAX_DRIFT_MS = 5000`. If the counter drifts more than 5 seconds ahead of real time, `IdOverflowException` is thrown. This prevents unbounded future-dated timestamps under sustained high throughput.
+`MAX_DRIFT_MS = 10000`. If the counter drifts more than 10 seconds ahead of real time, `IdOverflowException` is thrown. This prevents unbounded future-dated timestamps under sustained high throughput.
 
-Practical impact: ~5,000 IDs/ms sustained before the cap triggers. Normal workloads never hit this.
+Practical impact: ~10,000 IDs/ms sustained before the cap triggers. Normal workloads never hit this.
 
 ### Forward clock jumps
 

--- a/src/HybridIdGenerator.php
+++ b/src/HybridIdGenerator.php
@@ -62,7 +62,7 @@ final class HybridIdGenerator implements IdGenerator
      * When exceeded, generation throws IdOverflowException to prevent unbounded
      * future-dated timestamps.
      */
-    public const int DEFAULT_MAX_DRIFT_MS = 5000;
+    public const int DEFAULT_MAX_DRIFT_MS = 10000;
 
     private readonly int $maxDriftMs;
 
@@ -261,7 +261,7 @@ final class HybridIdGenerator implements IdGenerator
     }
 
     /**
-     * Generate a compact ID (16 chars: 8ts + 2node + 6random, ~35.7 bits entropy).
+     * Generate a compact ID (16 chars: 8ts + 8random, ~47.6 bits entropy).
      *
      * @note For multi-node deployments with more than a few hundred IDs/second,
      *       prefer standard() or extended() and set explicit node IDs.

--- a/tests/Exception/ExceptionHierarchyTest.php
+++ b/tests/Exception/ExceptionHierarchyTest.php
@@ -20,6 +20,7 @@ final class ExceptionHierarchyTest extends TestCase
 
     public function testHybridIdExceptionExtendsThrowable(): void
     {
+        // @phpstan-ignore function.alreadyNarrowedType
         $this->assertTrue(is_a(HybridIdException::class, \Throwable::class, true));
     }
 
@@ -135,6 +136,7 @@ final class ExceptionHierarchyTest extends TestCase
                 continue;
             }
 
+            // @phpstan-ignore deadCode.unreachable
             $this->fail(sprintf('%s was not caught by HybridIdException', $e::class));
         }
     }

--- a/tests/HybridIdGeneratorTest.php
+++ b/tests/HybridIdGeneratorTest.php
@@ -1336,6 +1336,7 @@ final class HybridIdGeneratorTest extends TestCase
         $this->assertIsInt($result['timestamp']);
         $this->assertInstanceOf(\DateTimeImmutable::class, $result['datetime']);
         $this->assertSame('A1', $result['node']);
+        // @phpstan-ignore argument.type
         $this->assertSame(10, strlen($result['random']));
     }
 
@@ -1349,6 +1350,7 @@ final class HybridIdGeneratorTest extends TestCase
         $this->assertTrue($result['valid']);
         $this->assertSame('usr', $result['prefix']);
         $this->assertSame('standard', $result['profile']);
+        // @phpstan-ignore argument.type
         $this->assertSame(20, strlen($result['body']));
         $this->assertSame('B2', $result['node']);
     }
@@ -1363,12 +1365,15 @@ final class HybridIdGeneratorTest extends TestCase
 
         $this->assertSame('compact', $compact['profile']);
         $this->assertNull($compact['node']); // compact has no node
+        // @phpstan-ignore argument.type
         $this->assertSame(8, strlen($compact['random']));
 
         $this->assertSame('standard', $standard['profile']);
+        // @phpstan-ignore argument.type
         $this->assertSame(10, strlen($standard['random']));
 
         $this->assertSame('extended', $extended['profile']);
+        // @phpstan-ignore argument.type
         $this->assertSame(14, strlen($extended['random']));
     }
 
@@ -1620,6 +1625,7 @@ final class HybridIdGeneratorTest extends TestCase
 
         $this->expectException(\InvalidArgumentException::class);
 
+        // @phpstan-ignore argument.type
         $gen->generateBatch(0);
     }
 
@@ -1629,6 +1635,7 @@ final class HybridIdGeneratorTest extends TestCase
 
         $this->expectException(\InvalidArgumentException::class);
 
+        // @phpstan-ignore argument.type
         $gen->generateBatch(-1);
     }
 
@@ -1638,6 +1645,7 @@ final class HybridIdGeneratorTest extends TestCase
 
         $this->expectException(\InvalidArgumentException::class);
 
+        // @phpstan-ignore argument.type
         $gen->generateBatch(10_001);
     }
 

--- a/tests/HybridIdGeneratorTest.php
+++ b/tests/HybridIdGeneratorTest.php
@@ -208,19 +208,19 @@ final class HybridIdGeneratorTest extends TestCase
     {
         $gen = new HybridIdGenerator(requireExplicitNode: false);
 
-        // Generate enough IDs to push drift beyond 5000ms.
-        // Each call within the same ms increments by 1, so we need >5000 rapid calls.
+        // Generate enough IDs to push drift beyond 10000ms.
+        // Each call within the same ms increments by 1, so we need >10000 rapid calls.
         $this->expectException(IdOverflowException::class);
         $this->expectExceptionMessage('Monotonic timestamp drift exceeds');
 
-        for ($i = 0; $i < 10_000; $i++) {
+        for ($i = 0; $i < 15_000; $i++) {
             $gen->generate();
         }
     }
 
     public function testMonotonicDriftAllowsModerateRate(): void
     {
-        // A few hundred rapid calls should stay well within the 5000ms drift limit
+        // A few hundred rapid calls should stay well within the 10000ms drift limit
         $gen = new HybridIdGenerator(requireExplicitNode: false);
 
         for ($i = 0; $i < 200; $i++) {
@@ -228,6 +228,25 @@ final class HybridIdGeneratorTest extends TestCase
         }
 
         $this->assertTrue(HybridIdGenerator::isValid($id));
+    }
+
+    public function testMonotonicDriftToleratesUpToNewDefaultLimit(): void
+    {
+        // Regression guard for #217: the default drift cap was raised from 5000
+        // to 10000ms. 8000 rapid calls must NOT throw under the new default.
+        $gen = new HybridIdGenerator(requireExplicitNode: false);
+
+        for ($i = 0; $i < 8_000; $i++) {
+            $id = $gen->generate();
+        }
+
+        $this->assertTrue(HybridIdGenerator::isValid($id));
+    }
+
+    public function testDefaultMaxDriftMsMatchesBatchLimit(): void
+    {
+        // #217: default drift budget must cover generateBatch's maximum (10k IDs).
+        $this->assertSame(10_000, HybridIdGenerator::DEFAULT_MAX_DRIFT_MS);
     }
 
     // -------------------------------------------------------------------------

--- a/tests/PerformanceTest.php
+++ b/tests/PerformanceTest.php
@@ -101,7 +101,7 @@ final class PerformanceTest extends TestCase
     public function testGenerateBatch10000Under5s(): void
     {
         // Use higher drift cap — 10k IDs at sub-ms speed will drift the
-        // monotonic clock well beyond the default 5000ms cap.
+        // monotonic clock up to the default 10000ms cap, so we bump it.
         $gen = new HybridIdGenerator(node: 'A1', maxDriftMs: 60_000);
         $gen->generateBatch(1);
 

--- a/tests/ProfileRegistryTest.php
+++ b/tests/ProfileRegistryTest.php
@@ -142,6 +142,7 @@ final class ProfileRegistryTest extends TestCase
         $this->expectException(InvalidProfileException::class);
         $this->expectExceptionMessage('between 6 and 128');
 
+        // @phpstan-ignore argument.type
         $registry->register('weak', 5);
     }
 
@@ -152,6 +153,7 @@ final class ProfileRegistryTest extends TestCase
         $this->expectException(InvalidProfileException::class);
         $this->expectExceptionMessage('between 6 and 128');
 
+        // @phpstan-ignore argument.type
         $registry->register('huge', 129);
     }
 
@@ -161,6 +163,7 @@ final class ProfileRegistryTest extends TestCase
 
         $this->expectException(InvalidProfileException::class);
 
+        // @phpstan-ignore argument.type
         $registry->register('norandom', 0);
     }
 

--- a/tests/Testing/MockHybridIdGeneratorTest.php
+++ b/tests/Testing/MockHybridIdGeneratorTest.php
@@ -90,6 +90,7 @@ final class MockHybridIdGeneratorTest extends TestCase
 
         $this->expectException(\InvalidArgumentException::class);
 
+        // @phpstan-ignore argument.type
         $mock->generateBatch(0);
     }
 
@@ -99,6 +100,7 @@ final class MockHybridIdGeneratorTest extends TestCase
 
         $this->expectException(\InvalidArgumentException::class);
 
+        // @phpstan-ignore argument.type
         $mock->generateBatch(10_001);
     }
 
@@ -349,6 +351,7 @@ final class MockHybridIdGeneratorTest extends TestCase
 
         $this->expectException(\InvalidArgumentException::class);
 
+        // @phpstan-ignore argument.type
         $mock->generateBatch(0);
     }
 
@@ -358,6 +361,7 @@ final class MockHybridIdGeneratorTest extends TestCase
 
         $this->expectException(\InvalidArgumentException::class);
 
+        // @phpstan-ignore argument.type
         $mock->generateBatch(10_001);
     }
 }


### PR DESCRIPTION
This pull request addresses three separate issues:

- Closes #217: Increases `DEFAULT_MAX_DRIFT_MS` from 5000 to 10000 to match the `generateBatch()` limit.
- Closes #218: Adds `@phpstan-ignore` annotations to test files to suppress false positives on intentional exception triggers.
- Closes #221: Corrects the docblock for `compact()` to accurately reflect its structure (8 random chars, 0 node).