### PR TITLE
feat: Enhance CLI Output & Centralize Exception Messages

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -4,6 +4,12 @@
 ./vendor/bin/hybrid-id <command> [options]
 ```
 
+## Global Options
+
+| Flag | Description |
+|---|---|
+| `--json` | Emit machine-readable JSON from `generate`, `inspect`, and `profiles` (including errors). Useful for scripting and CI pipelines. |
+
 ## Commands
 
 ### `generate`
@@ -23,6 +29,8 @@ Generate one or more IDs.
 ./vendor/bin/hybrid-id generate -p compact -n 10
 ./vendor/bin/hybrid-id generate -p extended --node A1 --prefix txn
 ./vendor/bin/hybrid-id generate --blind
+./vendor/bin/hybrid-id --json generate -n 3
+# {"ids":["...","...","..."]}
 ```
 
 ### `inspect`

--- a/src/Cli/Application.php
+++ b/src/Cli/Application.php
@@ -12,6 +12,7 @@ use HybridId\HybridIdGenerator;
 final class Application
 {
     private OutputInterface $output;
+    private bool $json = false;
 
     public function __construct(?OutputInterface $output = null)
     {
@@ -24,9 +25,8 @@ final class Application
     public function run(array $argv): int
     {
         $jsonPos = array_search('--json', $argv, true);
-        $json = false;
         if ($jsonPos !== false) {
-            $json = true;
+            $this->json = true;
             unset($argv[$jsonPos]);
             $argv = array_values($argv);
         }
@@ -34,8 +34,8 @@ final class Application
         $command = $argv[1] ?? 'help';
 
         return match ($command) {
-            'generate' => $this->commandGenerate(array_slice($argv, 2), $json),
-            'inspect'  => $this->commandInspect(array_slice($argv, 2), $json),
+            'generate' => $this->commandGenerate(array_slice($argv, 2)),
+            'inspect'  => $this->commandInspect(array_slice($argv, 2)),
             'profiles' => $this->commandProfiles(),
             'help', '--help', '-h' => $this->commandHelp(),
             default => $this->commandHelp(unknown: $command),
@@ -49,7 +49,7 @@ final class Application
     /**
      * @param list<string> $args
      */
-    private function commandGenerate(array $args, bool $json = false): int
+    private function commandGenerate(array $args): int
     {
         $profile = 'standard';
         $count = 1;
@@ -62,55 +62,30 @@ final class Application
                 case '-p':
                 case '--profile':
                     if (!isset($args[$i + 1])) {
-                        if ($json) {
-                            $this->output->error(json_encode(['error' => 'Missing value for --profile']));
-                        } else {
-                            $this->output->error('Missing value for --profile');
-                        }
-                        return 1;
+                        return $this->emitError('Missing value for --profile');
                     }
                     $profile = $args[++$i];
                     break;
                 case '-n':
                 case '--count':
                     if (!isset($args[$i + 1])) {
-                        if ($json) {
-                            $this->output->error(json_encode(['error' => 'Missing value for --count']));
-                        } else {
-                            $this->output->error('Missing value for --count');
-                        }
-                        return 1;
+                        return $this->emitError('Missing value for --count');
                     }
                     $raw = filter_var($args[++$i], FILTER_VALIDATE_INT);
                     if ($raw === false) {
-                        if ($json) {
-                            $this->output->error(json_encode(['error' => 'Count must be a valid integer']));
-                        } else {
-                            $this->output->error('Count must be a valid integer');
-                        }
-                        return 1;
+                        return $this->emitError('Count must be a valid integer');
                     }
                     $count = $raw;
                     break;
                 case '--node':
                     if (!isset($args[$i + 1])) {
-                        if ($json) {
-                            $this->output->error(json_encode(['error' => 'Missing value for --node']));
-                        } else {
-                            $this->output->error('Missing value for --node');
-                        }
-                        return 1;
+                        return $this->emitError('Missing value for --node');
                     }
                     $node = $args[++$i];
                     break;
                 case '--prefix':
                     if (!isset($args[$i + 1])) {
-                        if ($json) {
-                            $this->output->error(json_encode(['error' => 'Missing value for --prefix']));
-                        } else {
-                            $this->output->error('Missing value for --prefix');
-                        }
-                        return 1;
+                        return $this->emitError('Missing value for --prefix');
                     }
                     $prefix = $args[++$i];
                     break;
@@ -122,41 +97,21 @@ final class Application
                     $msg = str_starts_with($arg, '-')
                         ? 'Unknown option: ' . self::sanitize($arg)
                         : 'Unexpected argument: ' . self::sanitize($arg);
-                    if ($json) {
-                        $this->output->error(json_encode(['error' => $msg]));
-                    } else {
-                        $this->output->error($msg);
-                    }
-                    return 1;
+                    return $this->emitError($msg);
             }
         }
 
         if ($count < 1) {
-            if ($json) {
-                $this->output->error(json_encode(['error' => 'Count must be a positive integer']));
-            } else {
-                $this->output->error('Count must be a positive integer');
-            }
-            return 1;
+            return $this->emitError('Count must be a positive integer');
         }
         if ($count > 10000) {
-            if ($json) {
-                $this->output->error(json_encode(['error' => 'Count must not exceed 10,000']));
-            } else {
-                $this->output->error('Count must not exceed 10,000');
-            }
-            return 1;
+            return $this->emitError('Count must not exceed 10,000');
         }
 
         try {
             $gen = new HybridIdGenerator(profile: $profile, node: $node, requireExplicitNode: false, blind: $blind);
         } catch (\InvalidArgumentException $e) {
-            if ($json) {
-                $this->output->error(json_encode(['error' => self::sanitize($e->getMessage())]));
-            } else {
-                $this->output->error(self::sanitize($e->getMessage()));
-            }
-            return 1;
+            return $this->emitError(self::sanitize($e->getMessage()));
         }
 
         $ids = [];
@@ -164,17 +119,12 @@ final class Application
             try {
                 $ids[] = $gen->generate($prefix);
             } catch (\Throwable $e) {
-                if ($json) {
-                    $this->output->error(json_encode(['error' => self::sanitize($e->getMessage())]));
-                } else {
-                    $this->output->error(self::sanitize($e->getMessage()));
-                }
-                return 1;
+                return $this->emitError(self::sanitize($e->getMessage()));
             }
         }
 
-        if ($json) {
-            $this->output->writeln(json_encode(['ids' => $ids]));
+        if ($this->json) {
+            $this->output->writeln(self::encodeJson(['ids' => $ids]));
         } else {
             foreach ($ids as $id) {
                 $this->output->writeln($id);
@@ -187,28 +137,18 @@ final class Application
     /**
      * @param list<string> $args
      */
-    private function commandInspect(array $args, bool $json = false): int
+    private function commandInspect(array $args): int
     {
         $id = $args[0] ?? null;
 
         if ($id === null || $id === '') {
-            if ($json) {
-                $this->output->error(json_encode(['error' => 'Usage: hybrid-id inspect <id>']));
-            } else {
-                $this->output->error('Usage: hybrid-id inspect <id>');
-            }
-            return 1;
+            return $this->emitError('Usage: hybrid-id inspect <id>');
         }
 
         $profile = HybridIdGenerator::detectProfile($id);
 
         if ($profile === null) {
-            if ($json) {
-                $this->output->error(json_encode(['error' => 'Invalid HybridId: ' . self::sanitize($id)]));
-            } else {
-                $this->output->error('Invalid HybridId: ' . self::sanitize($id));
-            }
-            return 1;
+            return $this->emitError('Invalid HybridId: ' . self::sanitize($id));
         }
 
         $prefix = HybridIdGenerator::extractPrefix($id);
@@ -221,8 +161,8 @@ final class Application
         $random = substr($rawId, $randomOffset);
         $entropy = HybridIdGenerator::entropy($profile);
 
-        if ($json) {
-            $this->output->writeln(json_encode([
+        if ($this->json) {
+            $this->output->writeln(self::encodeJson([
                 'id' => $id,
                 'prefix' => $prefix,
                 'profile' => $profile,
@@ -258,9 +198,24 @@ final class Application
 
     private function commandProfiles(): int
     {
-        $this->output->writeln('');
-        $this->output->writeln('  Profile     Length   Structure              Random bits   vs UUID v7');
-        $this->output->writeln('  -------     ------   ---------              -----------   ----------');
+        $profiles = [];
+        foreach (HybridIdGenerator::profiles() as $name) {
+            $config = HybridIdGenerator::profileConfig($name);
+            $entropy = HybridIdGenerator::entropy($name);
+            $profiles[] = [
+                'name' => $name,
+                'length' => $config['length'],
+                'ts' => $config['ts'],
+                'node' => $config['node'],
+                'random' => $config['random'],
+                'entropy_bits' => $entropy,
+            ];
+        }
+
+        if ($this->json) {
+            $this->output->writeln(self::encodeJson(['profiles' => $profiles]));
+            return 0;
+        }
 
         $comparisons = [
             'compact'  => '< UUID v7',
@@ -268,20 +223,22 @@ final class Application
             'extended' => '> UUID v7',
         ];
 
-        foreach (HybridIdGenerator::profiles() as $name) {
-            $config = HybridIdGenerator::profileConfig($name);
-            $entropy = HybridIdGenerator::entropy($name);
-            $structure = $config['node'] > 0
-                ? "{$config['ts']}ts + {$config['node']}node + {$config['random']}rand"
-                : "{$config['ts']}ts + {$config['random']}rand";
-            $cmp = $comparisons[$name] ?? 'custom';
+        $this->output->writeln('');
+        $this->output->writeln('  Profile     Length   Structure              Random bits   vs UUID v7');
+        $this->output->writeln('  -------     ------   ---------              -----------   ----------');
+
+        foreach ($profiles as $p) {
+            $structure = $p['node'] > 0
+                ? "{$p['ts']}ts + {$p['node']}node + {$p['random']}rand"
+                : "{$p['ts']}ts + {$p['random']}rand";
+            $cmp = $comparisons[$p['name']] ?? 'custom';
 
             $this->output->writeln(sprintf(
                 '  %-10s  %-7d  %-21s  %-12s  %s',
-                $name,
-                $config['length'],
+                $p['name'],
+                $p['length'],
                 $structure,
-                "{$entropy} bits",
+                "{$p['entropy_bits']} bits",
                 $cmp,
             ));
         }
@@ -313,7 +270,7 @@ final class Application
         $this->output->writeln('  --blind                Generate using blind mode (requires HYBRID_ID_BLIND_SECRET)');
         $this->output->writeln('');
         $this->output->writeln('Global options:');
-        $this->output->writeln('  --json                 Output in JSON format (applies to generate and inspect)');
+        $this->output->writeln('  --json                 Output in JSON format (generate, inspect, profiles)');
         $this->output->writeln('');
         $this->output->writeln('Examples:');
         $this->output->writeln('  hybrid-id generate');
@@ -321,6 +278,7 @@ final class Application
         $this->output->writeln('  hybrid-id generate -p extended --node A1');
         $this->output->writeln('  hybrid-id generate --prefix usr');
         $this->output->writeln('  hybrid-id inspect usr_0A1b2C3dX9YyZzWwQq12');
+        $this->output->writeln('  hybrid-id generate --json -n 3');
         $this->output->writeln('');
 
         return $unknown !== null ? 1 : 0;
@@ -331,6 +289,27 @@ final class Application
     // -------------------------------------------------------------------------
 
     private const int MAX_INPUT_LENGTH = 256;
+
+    /**
+     * Emit an error in the active output format (text or JSON) and return exit code 1.
+     */
+    private function emitError(string $message): int
+    {
+        if ($this->json) {
+            $this->output->error(self::encodeJson(['error' => $message]));
+        } else {
+            $this->output->error($message);
+        }
+        return 1;
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private static function encodeJson(array $data): string
+    {
+        return json_encode($data, JSON_THROW_ON_ERROR);
+    }
 
     private static function sanitize(string $input): string
     {

--- a/src/Cli/Application.php
+++ b/src/Cli/Application.php
@@ -23,11 +23,19 @@ final class Application
      */
     public function run(array $argv): int
     {
+        $jsonPos = array_search('--json', $argv, true);
+        $json = false;
+        if ($jsonPos !== false) {
+            $json = true;
+            unset($argv[$jsonPos]);
+            $argv = array_values($argv);
+        }
+
         $command = $argv[1] ?? 'help';
 
         return match ($command) {
-            'generate' => $this->commandGenerate(array_slice($argv, 2)),
-            'inspect'  => $this->commandInspect(array_slice($argv, 2)),
+            'generate' => $this->commandGenerate(array_slice($argv, 2), $json),
+            'inspect'  => $this->commandInspect(array_slice($argv, 2), $json),
             'profiles' => $this->commandProfiles(),
             'help', '--help', '-h' => $this->commandHelp(),
             default => $this->commandHelp(unknown: $command),
@@ -41,7 +49,7 @@ final class Application
     /**
      * @param list<string> $args
      */
-    private function commandGenerate(array $args): int
+    private function commandGenerate(array $args, bool $json = false): int
     {
         $profile = 'standard';
         $count = 1;
@@ -54,7 +62,11 @@ final class Application
                 case '-p':
                 case '--profile':
                     if (!isset($args[$i + 1])) {
-                        $this->output->error('Missing value for --profile');
+                        if ($json) {
+                            $this->output->error(json_encode(['error' => 'Missing value for --profile']));
+                        } else {
+                            $this->output->error('Missing value for --profile');
+                        }
                         return 1;
                     }
                     $profile = $args[++$i];
@@ -62,26 +74,42 @@ final class Application
                 case '-n':
                 case '--count':
                     if (!isset($args[$i + 1])) {
-                        $this->output->error('Missing value for --count');
+                        if ($json) {
+                            $this->output->error(json_encode(['error' => 'Missing value for --count']));
+                        } else {
+                            $this->output->error('Missing value for --count');
+                        }
                         return 1;
                     }
                     $raw = filter_var($args[++$i], FILTER_VALIDATE_INT);
                     if ($raw === false) {
-                        $this->output->error('Count must be a valid integer');
+                        if ($json) {
+                            $this->output->error(json_encode(['error' => 'Count must be a valid integer']));
+                        } else {
+                            $this->output->error('Count must be a valid integer');
+                        }
                         return 1;
                     }
                     $count = $raw;
                     break;
                 case '--node':
                     if (!isset($args[$i + 1])) {
-                        $this->output->error('Missing value for --node');
+                        if ($json) {
+                            $this->output->error(json_encode(['error' => 'Missing value for --node']));
+                        } else {
+                            $this->output->error('Missing value for --node');
+                        }
                         return 1;
                     }
                     $node = $args[++$i];
                     break;
                 case '--prefix':
                     if (!isset($args[$i + 1])) {
-                        $this->output->error('Missing value for --prefix');
+                        if ($json) {
+                            $this->output->error(json_encode(['error' => 'Missing value for --prefix']));
+                        } else {
+                            $this->output->error('Missing value for --prefix');
+                        }
                         return 1;
                     }
                     $prefix = $args[++$i];
@@ -91,37 +119,65 @@ final class Application
                     break;
                 default:
                     $arg = (string) $args[$i];
-                    $this->output->error(
-                        str_starts_with($arg, '-')
-                            ? 'Unknown option: ' . self::sanitize($arg)
-                            : 'Unexpected argument: ' . self::sanitize($arg),
-                    );
+                    $msg = str_starts_with($arg, '-')
+                        ? 'Unknown option: ' . self::sanitize($arg)
+                        : 'Unexpected argument: ' . self::sanitize($arg);
+                    if ($json) {
+                        $this->output->error(json_encode(['error' => $msg]));
+                    } else {
+                        $this->output->error($msg);
+                    }
                     return 1;
             }
         }
 
         if ($count < 1) {
-            $this->output->error('Count must be a positive integer');
+            if ($json) {
+                $this->output->error(json_encode(['error' => 'Count must be a positive integer']));
+            } else {
+                $this->output->error('Count must be a positive integer');
+            }
             return 1;
         }
         if ($count > 10000) {
-            $this->output->error('Count must not exceed 10,000');
+            if ($json) {
+                $this->output->error(json_encode(['error' => 'Count must not exceed 10,000']));
+            } else {
+                $this->output->error('Count must not exceed 10,000');
+            }
             return 1;
         }
 
         try {
             $gen = new HybridIdGenerator(profile: $profile, node: $node, requireExplicitNode: false, blind: $blind);
         } catch (\InvalidArgumentException $e) {
-            $this->output->error(self::sanitize($e->getMessage()));
+            if ($json) {
+                $this->output->error(json_encode(['error' => self::sanitize($e->getMessage())]));
+            } else {
+                $this->output->error(self::sanitize($e->getMessage()));
+            }
             return 1;
         }
 
+        $ids = [];
         for ($i = 0; $i < $count; $i++) {
             try {
-                $this->output->writeln($gen->generate($prefix));
+                $ids[] = $gen->generate($prefix);
             } catch (\Throwable $e) {
-                $this->output->error(self::sanitize($e->getMessage()));
+                if ($json) {
+                    $this->output->error(json_encode(['error' => self::sanitize($e->getMessage())]));
+                } else {
+                    $this->output->error(self::sanitize($e->getMessage()));
+                }
                 return 1;
+            }
+        }
+
+        if ($json) {
+            $this->output->writeln(json_encode(['ids' => $ids]));
+        } else {
+            foreach ($ids as $id) {
+                $this->output->writeln($id);
             }
         }
 
@@ -131,19 +187,27 @@ final class Application
     /**
      * @param list<string> $args
      */
-    private function commandInspect(array $args): int
+    private function commandInspect(array $args, bool $json = false): int
     {
         $id = $args[0] ?? null;
 
         if ($id === null || $id === '') {
-            $this->output->error('Usage: hybrid-id inspect <id>');
+            if ($json) {
+                $this->output->error(json_encode(['error' => 'Usage: hybrid-id inspect <id>']));
+            } else {
+                $this->output->error('Usage: hybrid-id inspect <id>');
+            }
             return 1;
         }
 
         $profile = HybridIdGenerator::detectProfile($id);
 
         if ($profile === null) {
-            $this->output->error('Invalid HybridId: ' . self::sanitize($id));
+            if ($json) {
+                $this->output->error(json_encode(['error' => 'Invalid HybridId: ' . self::sanitize($id)]));
+            } else {
+                $this->output->error('Invalid HybridId: ' . self::sanitize($id));
+            }
             return 1;
         }
 
@@ -156,6 +220,22 @@ final class Application
         $randomOffset = 8 + $config['node'];
         $random = substr($rawId, $randomOffset);
         $entropy = HybridIdGenerator::entropy($profile);
+
+        if ($json) {
+            $this->output->writeln(json_encode([
+                'id' => $id,
+                'prefix' => $prefix,
+                'profile' => $profile,
+                'length' => $config['length'],
+                'timestamp' => $timestamp,
+                'datetime' => $datetime->format('Y-m-d H:i:s.v'),
+                'node' => $node,
+                'random' => $random,
+                'entropy_bits' => $entropy,
+                'valid' => true,
+            ]));
+            return 0;
+        }
 
         $this->output->writeln('');
         $this->output->writeln("  ID:         {$id}");
@@ -230,6 +310,10 @@ final class Application
         $this->output->writeln('  -n, --count <number>   Number of IDs to generate (default: 1)');
         $this->output->writeln('  --node <XX>            Node identifier (2 base62 chars)');
         $this->output->writeln('  --prefix <name>        Prefix for self-documenting IDs (e.g., usr, ord)');
+        $this->output->writeln('  --blind                Generate using blind mode (requires HYBRID_ID_BLIND_SECRET)');
+        $this->output->writeln('');
+        $this->output->writeln('Global options:');
+        $this->output->writeln('  --json                 Output in JSON format (applies to generate and inspect)');
         $this->output->writeln('');
         $this->output->writeln('Examples:');
         $this->output->writeln('  hybrid-id generate');

--- a/src/Exception/Messages.php
+++ b/src/Exception/Messages.php
@@ -7,7 +7,10 @@ namespace HybridId\Exception;
 /**
  * Centralized exception messages.
  *
- * @internal
+ * @internal These constants are an implementation detail and may change
+ *           between minor versions. Do NOT assert against them in downstream
+ *           test suites — use substring matching on `$e->getMessage()` or
+ *           catch specific exception classes instead.
  */
 final class Messages
 {

--- a/src/Exception/Messages.php
+++ b/src/Exception/Messages.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HybridId\Exception;
+
+/**
+ * Centralized exception messages.
+ *
+ * @internal
+ */
+final class Messages
+{
+    // ProfileRegistry
+    public const PROFILE_NAME_INVALID = 'Profile name must be lowercase alphanumeric, starting with a letter';
+    public const PROFILE_EXISTS = 'Profile "%s" already exists';
+    public const RANDOM_LENGTH_INVALID = 'Random length must be between 6 and 128';
+    public const LENGTH_CONFLICT = 'Length %d conflicts with existing profile "%s"';
+
+    // MockHybridIdGenerator
+    public const MOCK_EMPTY = 'MockHybridIdGenerator requires at least one ID';
+    public const MOCK_PREFIX_MISMATCH = 'MockHybridIdGenerator: generate() called with prefix "%s" but ID "%s" does not start with "%s_". %s';
+    public const MOCK_BATCH_LIMIT = 'Batch count must be between 1 and 10,000, got %d';
+    public const MOCK_EXHAUSTED = 'MockHybridIdGenerator exhausted: all %d IDs have been consumed';
+
+    // UuidConverter
+    public const UUID_UNRECOGNIZED_PROFILE = 'Unrecognized profile index in UUIDv8';
+    public const UUID_PACK_UNSUPPORTED = 'Profile "%s" cannot be losslessly packed into UUIDv8 (max 60 random bits)';
+    public const UUID_NEGATIVE_TS = 'Timestamp must be non-negative';
+    public const UUID_TS_OVERFLOW = 'Timestamp exceeds maximum encodable value (62^8 - 1)';
+    public const UUID_NODE_INVALID = 'Node must be exactly 2 base62 characters';
+    public const UUID_INVALID_FORMAT = 'Invalid UUID format';
+    public const UUID_INVALID_VARIANT = 'Invalid UUID variant: expected RFC 4122 variant (10xx)';
+    public const UUID_EXPECTED_VERSION = 'Expected UUID version %d, got %d';
+    public const UUID_PROFILE_UNSUPPORTED = '%s() only supports compact and standard profiles (got "%s")';
+    public const UUID_PREFIX_REJECTED = '%s() does not accept prefixed IDs — prefixes are lost during UUID conversion. Strip the prefix first with HybridIdGenerator::extractPrefix() and track it separately.';
+    public const UUID_CONVERSION_INVALID = 'Invalid HybridId: cannot convert to %s';
+    public const UUID_HEX_OVERFLOW = 'Hex value exceeds 64-bit integer range';
+
+    // HybridIdGenerator
+    public const GEN_REQUIRE_64BIT = 'HybridId requires 64-bit PHP';
+    public const GEN_DRIFT_INVALID = 'maxDriftMs must be a positive integer, got %d';
+    public const GEN_PROFILE_UNKNOWN = 'Unknown profile "%s"';
+    public const GEN_BLIND_SECRET_LENGTH = 'blindSecret must be at least 32 bytes, got %d';
+    public const GEN_NODE_INVALID = 'Node must be exactly 2 base62 characters (0-9, A-Z, a-z)';
+    public const GEN_NODE_REQUIRED = 'Explicit node is required (requireExplicitNode is enabled). Provide a 2-character base62 node identifier via the node parameter or HYBRID_ID_NODE env var.';
+    public const GEN_MAX_LENGTH_INVALID = 'maxIdLength (%d) must be >= body length (%d) for profile "%s"';
+    public const GEN_ENV_PROFILE_INVALID = 'Invalid HYBRID_ID_PROFILE: "%s"';
+    public const GEN_ENV_NODE_INVALID = 'Invalid HYBRID_ID_NODE: "%s". Must be exactly 2 base62 characters.';
+    public const GEN_ENV_BLIND_SECRET_INVALID = 'HYBRID_ID_BLIND_SECRET must be valid base64';
+    public const GEN_ENV_MAX_LENGTH_INVALID = 'Invalid HYBRID_ID_MAX_LENGTH: "%s". Must be a positive integer.';
+    public const GEN_BATCH_LIMIT = 'Batch count must be between 1 and 10,000, got %d';
+    public const GEN_PREFIX_LENGTH = 'maxPrefixLength must be between 0 and %d';
+    public const GEN_DATETIME_FAILED = 'Failed to create DateTime from HybridId (timestamp: %d ms)';
+    public const GEN_DRIFT_EXCEEDED = 'Monotonic timestamp drift exceeds %dms. Reduce generation rate or use multiple instances.';
+    public const GEN_ID_LENGTH_EXCEEDED = 'Generated ID length %d exceeds maxIdLength %d. Use a shorter prefix or increase maxIdLength';
+    public const GEN_ENCODE_LENGTH = 'Length must be at least 1';
+    public const GEN_ENCODE_NEGATIVE = 'Cannot encode negative value';
+    public const GEN_ENCODE_OVERFLOW = 'Value exceeds maximum for %d base62 characters';
+    public const GEN_DECODE_EMPTY = 'Cannot decode empty string';
+    public const GEN_DECODE_OVERFLOW = 'Value exceeds 64-bit integer range';
+    public const GEN_DECODE_INVALID_CHAR = 'Invalid base62 character: %s';
+    public const GEN_FORMAT_INVALID = 'Invalid HybridId format';
+    public const GEN_PREFIX_FORMAT = 'Prefix must be 1-%d lowercase alphanumeric characters, starting with a letter';
+    public const GEN_URANDOM_FAILED = 'Failed to generate cryptographically secure random bytes';
+}

--- a/src/HybridId.php
+++ b/src/HybridId.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace HybridId;
 
 use HybridId\Exception\InvalidIdException;
+use HybridId\Exception\Messages;
 
 /**
  * Immutable Value Object representing a parsed HybridId.
@@ -28,7 +29,7 @@ final class HybridId implements \Stringable, \JsonSerializable
         $parsed = HybridIdGenerator::parse($id);
 
         if (!$parsed['valid']) {
-            throw new InvalidIdException(sprintf('Invalid HybridId format: "%s"', $id));
+            throw new InvalidIdException(sprintf('%s: "%s"', Messages::GEN_FORMAT_INVALID, $id));
         }
 
         /** @var string $profile */

--- a/src/HybridIdGenerator.php
+++ b/src/HybridIdGenerator.php
@@ -9,6 +9,7 @@ use HybridId\Exception\InvalidIdException;
 use HybridId\Exception\InvalidPrefixException;
 use HybridId\Exception\InvalidProfileException;
 use HybridId\Exception\NodeRequiredException;
+use HybridId\Exception\Messages;
 
 final class HybridIdGenerator implements IdGenerator
 {
@@ -77,12 +78,12 @@ final class HybridIdGenerator implements IdGenerator
         int $maxDriftMs = self::DEFAULT_MAX_DRIFT_MS,
     ) {
         if (PHP_INT_SIZE < 8) {
-            throw new \RuntimeException('HybridId requires 64-bit PHP');
+            throw new \RuntimeException(Messages::GEN_REQUIRE_64BIT);
         }
 
         if ($maxDriftMs < 1) {
             throw new \InvalidArgumentException(
-                sprintf('maxDriftMs must be a positive integer, got %d', $maxDriftMs),
+                sprintf(Messages::GEN_DRIFT_INVALID, $maxDriftMs),
             );
         }
         $this->maxDriftMs = $maxDriftMs;
@@ -93,7 +94,7 @@ final class HybridIdGenerator implements IdGenerator
         $config = $this->registry->get($profileName);
         if ($config === null) {
             throw new InvalidProfileException(
-                sprintf('Unknown profile "%s"', $profileName),
+                sprintf(Messages::GEN_PROFILE_UNKNOWN, $profileName),
             );
         }
         $this->profile = $profileName;
@@ -101,14 +102,14 @@ final class HybridIdGenerator implements IdGenerator
         $this->blind = $blind || $blindSecret !== null;
         if ($blindSecret !== null && strlen($blindSecret) < 32) {
             throw new \InvalidArgumentException(
-                sprintf('blindSecret must be at least 32 bytes, got %d', strlen($blindSecret)),
+                sprintf(Messages::GEN_BLIND_SECRET_LENGTH, strlen($blindSecret)),
             );
         }
         $this->blindSecret = $this->blind ? ($blindSecret ?? self::secureRandomBytes(32)) : null;
 
         if ($node !== null) {
             if (strlen($node) !== 2 || !self::isBase62String($node)) {
-                throw new InvalidIdException('Node must be exactly 2 base62 characters (0-9, A-Z, a-z)');
+                throw new InvalidIdException(Messages::GEN_NODE_INVALID);
             }
             $this->node = $node;
         } elseif ($this->profileConfig['node'] === 0) {
@@ -117,10 +118,7 @@ final class HybridIdGenerator implements IdGenerator
             // Blind mode: node is only used as HMAC input, secret differentiates instances
             $this->node = self::autoDetectNode();
         } elseif ($requireExplicitNode && $this->profileConfig['node'] > 0) {
-            throw new NodeRequiredException(
-                'Explicit node is required (requireExplicitNode is enabled). '
-                . 'Provide a 2-character base62 node identifier via the node parameter or HYBRID_ID_NODE env var.',
-            );
+            throw new NodeRequiredException(Messages::GEN_NODE_REQUIRED);
         } else {
             $this->node = self::autoDetectNode();
         }
@@ -129,7 +127,7 @@ final class HybridIdGenerator implements IdGenerator
             if ($maxIdLength < $this->profileConfig['length']) {
                 throw new IdOverflowException(
                     sprintf(
-                        'maxIdLength (%d) must be >= body length (%d) for profile "%s"',
+                        Messages::GEN_MAX_LENGTH_INVALID,
                         $maxIdLength,
                         $this->profileConfig['length'],
                         $profileName,
@@ -165,14 +163,14 @@ final class HybridIdGenerator implements IdGenerator
         $profile = Profile::tryFrom($profileValue) ?? $profileValue;
         if (is_string($profile) && $reg->get($profile) === null) {
             throw new InvalidProfileException(
-                sprintf('Invalid HYBRID_ID_PROFILE: "%s"', self::truncateForMessage($profileValue)),
+                sprintf(Messages::GEN_ENV_PROFILE_INVALID, self::truncateForMessage($profileValue)),
             );
         }
 
         $node = self::readEnv('HYBRID_ID_NODE');
         if ($node !== null && (strlen($node) !== 2 || !self::isBase62String($node))) {
             throw new \InvalidArgumentException(
-                sprintf('Invalid HYBRID_ID_NODE: "%s". Must be exactly 2 base62 characters.', self::truncateForMessage($node)),
+                sprintf(Messages::GEN_ENV_NODE_INVALID, self::truncateForMessage($node)),
             );
         }
 
@@ -187,7 +185,7 @@ final class HybridIdGenerator implements IdGenerator
         $blindSecretEnv = self::readEnv('HYBRID_ID_BLIND_SECRET');
         $blindSecret = $blindSecretEnv !== null ? base64_decode($blindSecretEnv, true) : null;
         if ($blindSecretEnv !== null && ($blindSecret === false || $blindSecret === '')) {
-            throw new \InvalidArgumentException('HYBRID_ID_BLIND_SECRET must be valid base64');
+            throw new \InvalidArgumentException(Messages::GEN_ENV_BLIND_SECRET_INVALID);
         }
 
         $maxLengthEnv = self::readEnv('HYBRID_ID_MAX_LENGTH');
@@ -196,7 +194,7 @@ final class HybridIdGenerator implements IdGenerator
             $maxIdLength = filter_var($maxLengthEnv, FILTER_VALIDATE_INT);
             if ($maxIdLength === false || $maxIdLength < 1) {
                 throw new \InvalidArgumentException(
-                    sprintf('Invalid HYBRID_ID_MAX_LENGTH: "%s". Must be a positive integer.', self::truncateForMessage($maxLengthEnv)),
+                    sprintf(Messages::GEN_ENV_MAX_LENGTH_INVALID, self::truncateForMessage($maxLengthEnv)),
                 );
             }
         }
@@ -318,7 +316,7 @@ final class HybridIdGenerator implements IdGenerator
     {
         if ($count < 1 || $count > 10_000) {
             throw new \InvalidArgumentException(
-                sprintf('Batch count must be between 1 and 10,000, got %d', $count),
+                sprintf(Messages::GEN_BATCH_LIMIT, $count),
             );
         }
 
@@ -458,7 +456,7 @@ final class HybridIdGenerator implements IdGenerator
     {
         if ($maxPrefixLength < 0 || $maxPrefixLength > self::PREFIX_MAX_LENGTH) {
             throw new InvalidPrefixException(
-                sprintf('maxPrefixLength must be between 0 and %d', self::PREFIX_MAX_LENGTH),
+                sprintf(Messages::GEN_PREFIX_LENGTH, self::PREFIX_MAX_LENGTH),
             );
         }
 
@@ -569,7 +567,7 @@ final class HybridIdGenerator implements IdGenerator
             // @codeCoverageIgnoreStart — unreachable: extractTimestamp() validates
             // the ID and any valid millisecond timestamp produces a valid DateTime.
             throw new \RuntimeException(
-                sprintf('Failed to create DateTime from HybridId (timestamp: %d ms)', $timestampMs),
+                sprintf(Messages::GEN_DATETIME_FAILED, $timestampMs),
             );
             // @codeCoverageIgnoreEnd
         }
@@ -654,7 +652,7 @@ final class HybridIdGenerator implements IdGenerator
 
         if ($config === null) {
             throw new InvalidProfileException(
-                sprintf('Unknown profile "%s"', $profileName),
+                sprintf(Messages::GEN_PROFILE_UNKNOWN, $profileName),
             );
         }
 
@@ -677,7 +675,7 @@ final class HybridIdGenerator implements IdGenerator
 
         if ($config === null) {
             throw new InvalidProfileException(
-                sprintf('Unknown profile "%s"', $profileName),
+                sprintf(Messages::GEN_PROFILE_UNKNOWN, $profileName),
             );
         }
 
@@ -838,7 +836,7 @@ final class HybridIdGenerator implements IdGenerator
         $config = $profile === $this->profile ? $this->profileConfig : $this->registry->get($profile);
 
         if ($config === null) {
-            throw new \InvalidArgumentException(sprintf('Unknown profile "%s"', $profile));
+            throw new \InvalidArgumentException(sprintf(Messages::GEN_PROFILE_UNKNOWN, $profile));
         }
 
         $now = (int) (microtime(true) * 1000);
@@ -854,7 +852,7 @@ final class HybridIdGenerator implements IdGenerator
             if ($now - $realNow > $this->maxDriftMs) {
                 throw new IdOverflowException(
                     sprintf(
-                        'Monotonic timestamp drift exceeds %dms. Reduce generation rate or use multiple instances.',
+                        Messages::GEN_DRIFT_EXCEEDED,
                         $this->maxDriftMs,
                     ),
                 );
@@ -891,7 +889,7 @@ final class HybridIdGenerator implements IdGenerator
         if ($this->maxIdLength !== null && strlen($fullId) > $this->maxIdLength) {
             throw new IdOverflowException(
                 sprintf(
-                    'Generated ID length %d exceeds maxIdLength %d. Use a shorter prefix or increase maxIdLength',
+                    Messages::GEN_ID_LENGTH_EXCEEDED,
                     strlen($fullId),
                     $this->maxIdLength,
                 ),
@@ -932,11 +930,11 @@ final class HybridIdGenerator implements IdGenerator
     public static function encodeBase62(int $num, int $length): string
     {
         if ($length < 1) {
-            throw new \InvalidArgumentException('Length must be at least 1');
+            throw new \InvalidArgumentException(Messages::GEN_ENCODE_LENGTH);
         }
 
         if ($num < 0) {
-            throw new IdOverflowException('Cannot encode negative value');
+            throw new IdOverflowException(Messages::GEN_ENCODE_NEGATIVE);
         }
 
         if ($num === 0) {
@@ -953,7 +951,7 @@ final class HybridIdGenerator implements IdGenerator
 
         if (strlen($encoded) > $length) {
             throw new IdOverflowException(
-                sprintf('Value exceeds maximum for %d base62 characters', $length),
+                sprintf(Messages::GEN_ENCODE_OVERFLOW, $length),
             );
         }
 
@@ -973,7 +971,7 @@ final class HybridIdGenerator implements IdGenerator
     public static function decodeBase62(string $str): int
     {
         if ($str === '') {
-            throw new InvalidIdException('Cannot decode empty string');
+            throw new InvalidIdException(Messages::GEN_DECODE_EMPTY);
         }
 
         // Early guard: strip leading zeros to count significant digits.
@@ -982,7 +980,7 @@ final class HybridIdGenerator implements IdGenerator
         // may or may not overflow, so the arithmetic check handles those.
         $significant = ltrim($str, '0');
         if ($significant !== '' && strlen($significant) > 11) {
-            throw new IdOverflowException('Value exceeds 64-bit integer range');
+            throw new IdOverflowException(Messages::GEN_DECODE_OVERFLOW);
         }
 
         $result = 0;
@@ -992,14 +990,14 @@ final class HybridIdGenerator implements IdGenerator
             $pos = self::BASE62_MAP[$str[$i]] ?? null;
 
             if ($pos === null) {
-                throw new InvalidIdException("Invalid base62 character: {$str[$i]}");
+                throw new InvalidIdException(sprintf(Messages::GEN_DECODE_INVALID_CHAR, $str[$i]));
             }
 
             // Check for overflow before performing the operation.
             // This avoids relying on is_float() which may not catch all
             // overflow scenarios (e.g. silent wrap to negative on some builds).
             if ($result > intdiv(PHP_INT_MAX - $pos, 62)) {
-                throw new IdOverflowException('Value exceeds 64-bit integer range');
+                throw new IdOverflowException(Messages::GEN_DECODE_OVERFLOW);
             }
 
             $result = $result * 62 + $pos;
@@ -1047,7 +1045,7 @@ final class HybridIdGenerator implements IdGenerator
     private static function assertValid(string $id): void
     {
         if (!self::isValid($id)) {
-            throw new InvalidIdException('Invalid HybridId format');
+            throw new InvalidIdException(Messages::GEN_FORMAT_INVALID);
         }
     }
 
@@ -1074,7 +1072,7 @@ final class HybridIdGenerator implements IdGenerator
         if (!self::isValidPrefix($prefix)) {
             throw new InvalidPrefixException(
                 sprintf(
-                    'Prefix must be 1-%d lowercase alphanumeric characters, starting with a letter',
+                    Messages::GEN_PREFIX_FORMAT,
                     self::PREFIX_MAX_LENGTH,
                 ),
             );
@@ -1088,13 +1086,13 @@ final class HybridIdGenerator implements IdGenerator
     private static function secureRandomBytes(int $length): string
     {
         if ($length < 1) {
-            throw new \InvalidArgumentException('Length must be at least 1');
+            throw new \InvalidArgumentException(Messages::GEN_ENCODE_LENGTH);
         }
         try {
             return random_bytes($length);
         } catch (\Random\RandomException $e) {
             throw new \RuntimeException(
-                'Failed to generate cryptographically secure random bytes',
+                Messages::GEN_URANDOM_FAILED,
                 0,
                 $e,
             );

--- a/src/HybridIdGenerator.php
+++ b/src/HybridIdGenerator.php
@@ -8,8 +8,8 @@ use HybridId\Exception\IdOverflowException;
 use HybridId\Exception\InvalidIdException;
 use HybridId\Exception\InvalidPrefixException;
 use HybridId\Exception\InvalidProfileException;
-use HybridId\Exception\NodeRequiredException;
 use HybridId\Exception\Messages;
+use HybridId\Exception\NodeRequiredException;
 
 final class HybridIdGenerator implements IdGenerator
 {

--- a/src/ProfileRegistry.php
+++ b/src/ProfileRegistry.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace HybridId;
 
 use HybridId\Exception\InvalidProfileException;
+use HybridId\Exception\Messages;
 
 /** @since 4.0.0 */
 final class ProfileRegistry implements ProfileRegistryInterface
@@ -48,17 +49,17 @@ final class ProfileRegistry implements ProfileRegistryInterface
     public function register(string $name, int $random, int $node = 2): void
     {
         if (!preg_match('/^[a-z][a-z0-9]*$/', $name)) {
-            throw new InvalidProfileException('Profile name must be lowercase alphanumeric, starting with a letter');
+            throw new InvalidProfileException(Messages::PROFILE_NAME_INVALID);
         }
 
         if ($this->get($name) !== null) {
             throw new InvalidProfileException(
-                sprintf('Profile "%s" already exists', $name),
+                sprintf(Messages::PROFILE_EXISTS, $name),
             );
         }
 
         if ($random < 6 || $random > 128) {
-            throw new InvalidProfileException('Random length must be between 6 and 128');
+            throw new InvalidProfileException(Messages::RANDOM_LENGTH_INVALID);
         }
 
         if ($node < 0 || $node > 10) {
@@ -70,7 +71,7 @@ final class ProfileRegistry implements ProfileRegistryInterface
         $existing = $this->getByLength($length);
         if ($existing !== null) {
             throw new InvalidProfileException(
-                sprintf('Length %d conflicts with existing profile "%s"', $length, $existing),
+                sprintf(Messages::LENGTH_CONFLICT, $length, $existing),
             );
         }
 

--- a/src/Testing/MockHybridIdGenerator.php
+++ b/src/Testing/MockHybridIdGenerator.php
@@ -6,6 +6,7 @@ namespace HybridId\Testing;
 
 use HybridId\HybridIdGenerator;
 use HybridId\IdGenerator;
+use HybridId\Exception\Messages;
 
 /** @since 4.0.0 */
 final class MockHybridIdGenerator implements IdGenerator
@@ -25,7 +26,7 @@ final class MockHybridIdGenerator implements IdGenerator
         private readonly ?\Closure $callback = null,
     ) {
         if ($this->callback === null && $ids === []) {
-            throw new \InvalidArgumentException('MockHybridIdGenerator requires at least one ID');
+            throw new \InvalidArgumentException(Messages::MOCK_EMPTY);
         }
 
         $this->ids = array_values($ids);
@@ -63,8 +64,7 @@ final class MockHybridIdGenerator implements IdGenerator
         if ($prefix !== null && !str_starts_with($id, $prefix . '_')) {
             throw new \LogicException(
                 sprintf(
-                    'MockHybridIdGenerator: generate() called with prefix "%s" but ID "%s" '
-                    . 'does not start with "%s_". %s',
+                    Messages::MOCK_PREFIX_MISMATCH,
                     $prefix,
                     $id,
                     $prefix,
@@ -83,7 +83,7 @@ final class MockHybridIdGenerator implements IdGenerator
     {
         if ($count < 1 || $count > 10_000) {
             throw new \InvalidArgumentException(
-                sprintf('Batch count must be between 1 and 10,000, got %d', $count),
+                sprintf(Messages::MOCK_BATCH_LIMIT, $count),
             );
         }
 
@@ -141,7 +141,7 @@ final class MockHybridIdGenerator implements IdGenerator
         if ($this->cursor >= count($this->ids)) {
             throw new \OverflowException(
                 sprintf(
-                    'MockHybridIdGenerator exhausted: all %d IDs have been consumed',
+                    Messages::MOCK_EXHAUSTED,
                     count($this->ids),
                 ),
             );

--- a/src/Testing/MockHybridIdGenerator.php
+++ b/src/Testing/MockHybridIdGenerator.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace HybridId\Testing;
 
+use HybridId\Exception\Messages;
 use HybridId\HybridIdGenerator;
 use HybridId\IdGenerator;
-use HybridId\Exception\Messages;
 
 /** @since 4.0.0 */
 final class MockHybridIdGenerator implements IdGenerator

--- a/src/Uuid/UuidConverter.php
+++ b/src/Uuid/UuidConverter.php
@@ -7,6 +7,7 @@ namespace HybridId\Uuid;
 use HybridId\Exception\IdOverflowException;
 use HybridId\Exception\InvalidIdException;
 use HybridId\Exception\InvalidProfileException;
+use HybridId\Exception\Messages;
 use HybridId\HybridIdGenerator;
 use HybridId\Profile;
 
@@ -42,7 +43,7 @@ final class UuidConverter
             'compact' => 0,
             'standard' => 1,
             default => throw new InvalidProfileException(
-                sprintf('Profile "%s" cannot be losslessly packed into UUIDv8 (max 60 random bits)', $parsed['profile']),
+                sprintf(Messages::UUID_PACK_UNSUPPORTED, $parsed['profile']),
             ),
         };
 
@@ -88,7 +89,7 @@ final class UuidConverter
         $profile = match ($profileIndex) {
             0 => 'compact',
             1 => 'standard',
-            default => throw new InvalidIdException('Unrecognized profile index in UUIDv8'),
+            default => throw new InvalidIdException(Messages::UUID_UNRECOGNIZED_PROFILE),
         };
 
         $config = HybridIdGenerator::profileConfig($profile);
@@ -218,15 +219,15 @@ final class UuidConverter
         $timestamp = $timestampMs ?? (int) (microtime(true) * 1000);
 
         if ($timestamp < 0) {
-            throw new InvalidIdException('Timestamp must be non-negative');
+            throw new InvalidIdException(Messages::UUID_NEGATIVE_TS);
         }
         if ($timestamp > 62 ** 8 - 1) {
-            throw new IdOverflowException('Timestamp exceeds maximum encodable value (62^8 - 1)');
+            throw new IdOverflowException(Messages::UUID_TS_OVERFLOW);
         }
 
         if ($node !== null) {
             if (strlen($node) !== 2 || strspn($node, HybridIdGenerator::BASE62) !== 2) {
-                throw new InvalidIdException('Node must be exactly 2 base62 characters');
+                throw new InvalidIdException(Messages::UUID_NODE_INVALID);
             }
             $nodeChars = $node;
         } else {
@@ -268,7 +269,7 @@ final class UuidConverter
         $parsed = HybridIdGenerator::parse($hybridId);
         if (!$parsed['valid']) {
             throw new InvalidIdException(
-                sprintf('Invalid HybridId: cannot convert to %s', $method),
+                sprintf(Messages::UUID_CONVERSION_INVALID, $method),
             );
         }
 
@@ -321,7 +322,7 @@ final class UuidConverter
     {
         $pattern = '/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i';
         if (preg_match($pattern, $uuid) !== 1) {
-            throw new InvalidIdException('Invalid UUID format');
+            throw new InvalidIdException(Messages::UUID_INVALID_FORMAT);
         }
 
         $hex = self::stripHyphens($uuid);
@@ -330,14 +331,14 @@ final class UuidConverter
         $version = hexdec($hex[12]);
         if ($version !== $expectedVersion) {
             throw new InvalidIdException(
-                sprintf('Expected UUID version %d, got %d', $expectedVersion, $version),
+                sprintf(Messages::UUID_EXPECTED_VERSION, $expectedVersion, $version),
             );
         }
 
         // Single hex digit (max 15): cannot overflow, safeHexdec not needed.
         $variantNibble = hexdec($hex[16]);
         if (($variantNibble >> 2) !== 0b10) {
-            throw new InvalidIdException('Invalid UUID variant: expected RFC 4122 variant (10xx)');
+            throw new InvalidIdException(Messages::UUID_INVALID_VARIANT);
         }
     }
 
@@ -346,7 +347,7 @@ final class UuidConverter
         if ($profile !== 'compact' && $profile !== 'standard') {
             throw new InvalidProfileException(
                 sprintf(
-                    '%s() only supports compact and standard profiles (got "%s")',
+                    Messages::UUID_PROFILE_UNSUPPORTED,
                     $method,
                     $profile,
                 ),
@@ -373,8 +374,7 @@ final class UuidConverter
         if (HybridIdGenerator::extractPrefix($hybridId) !== null) {
             throw new InvalidIdException(
                 sprintf(
-                    '%s() does not accept prefixed IDs — prefixes are lost during UUID conversion. '
-                    . 'Strip the prefix first with HybridIdGenerator::extractPrefix() and track it separately.',
+                    Messages::UUID_PREFIX_REJECTED,
                     $method,
                 ),
             );
@@ -384,11 +384,11 @@ final class UuidConverter
     private static function safeHexdec(string $hex): int
     {
         if (strlen($hex) > 15) {
-            throw new InvalidIdException('Hex value exceeds 64-bit integer range');
+            throw new InvalidIdException(Messages::UUID_HEX_OVERFLOW);
         }
         $result = hexdec($hex);
         if (is_float($result)) {
-            throw new InvalidIdException('Hex value exceeds 64-bit integer range');
+            throw new InvalidIdException(Messages::UUID_HEX_OVERFLOW);
         }
         return $result;
     }

--- a/tests/Cli/ApplicationTest.php
+++ b/tests/Cli/ApplicationTest.php
@@ -399,4 +399,114 @@ final class ApplicationTest extends TestCase
         // Null byte should be stripped
         $this->assertStringNotContainsString("\x00", $output->getErrors()[0]);
     }
+
+    // -------------------------------------------------------------------------
+    // --json flag
+    // -------------------------------------------------------------------------
+
+    public function testGenerateJsonOutput(): void
+    {
+        $output = new BufferedOutput();
+        $app = new Application($output);
+
+        $exitCode = $app->run(['hybrid-id', '--json', 'generate', '-n', '3']);
+
+        $this->assertSame(0, $exitCode);
+        $lines = $output->getLines();
+        $this->assertCount(1, $lines);
+
+        $decoded = json_decode($lines[0], true);
+        $this->assertIsArray($decoded);
+        $this->assertArrayHasKey('ids', $decoded);
+        $this->assertIsArray($decoded['ids']);
+        $this->assertCount(3, $decoded['ids']);
+        foreach ($decoded['ids'] as $id) {
+            $this->assertMatchesRegularExpression('/^[0-9A-Za-z]{20}$/', $id);
+        }
+    }
+
+    public function testGenerateJsonErrorOnInvalidCount(): void
+    {
+        $output = new BufferedOutput();
+        $app = new Application($output);
+
+        $exitCode = $app->run(['hybrid-id', '--json', 'generate', '-n', 'notanumber']);
+
+        $this->assertSame(1, $exitCode);
+        $errors = $output->getErrors();
+        $this->assertCount(1, $errors);
+
+        $decoded = json_decode($errors[0], true);
+        $this->assertIsArray($decoded);
+        $this->assertSame(['error' => 'Count must be a valid integer'], $decoded);
+    }
+
+    public function testInspectJsonOutput(): void
+    {
+        $gen = new HybridIdGenerator(node: 'T1');
+        $id = $gen->generate('usr');
+
+        $output = new BufferedOutput();
+        $app = new Application($output);
+
+        $exitCode = $app->run(['hybrid-id', '--json', 'inspect', $id]);
+
+        $this->assertSame(0, $exitCode);
+        $lines = $output->getLines();
+        $this->assertCount(1, $lines);
+
+        $decoded = json_decode($lines[0], true);
+        $this->assertIsArray($decoded);
+        $this->assertSame($id, $decoded['id']);
+        $this->assertSame('usr', $decoded['prefix']);
+        $this->assertSame('standard', $decoded['profile']);
+        $this->assertSame('T1', $decoded['node']);
+        $this->assertTrue($decoded['valid']);
+    }
+
+    public function testInspectJsonErrorOnInvalidId(): void
+    {
+        $output = new BufferedOutput();
+        $app = new Application($output);
+
+        $exitCode = $app->run(['hybrid-id', '--json', 'inspect', 'not-a-valid-id']);
+
+        $this->assertSame(1, $exitCode);
+        $decoded = json_decode($output->getErrors()[0], true);
+        $this->assertIsArray($decoded);
+        $this->assertArrayHasKey('error', $decoded);
+        $this->assertStringStartsWith('Invalid HybridId:', $decoded['error']);
+    }
+
+    public function testProfilesJsonOutput(): void
+    {
+        $output = new BufferedOutput();
+        $app = new Application($output);
+
+        $exitCode = $app->run(['hybrid-id', '--json', 'profiles']);
+
+        $this->assertSame(0, $exitCode);
+        $decoded = json_decode($output->getLines()[0], true);
+        $this->assertIsArray($decoded);
+        $this->assertArrayHasKey('profiles', $decoded);
+        $names = array_column($decoded['profiles'], 'name');
+        $this->assertContains('compact', $names);
+        $this->assertContains('standard', $names);
+        $this->assertContains('extended', $names);
+    }
+
+    public function testJsonFlagAcceptedBeforeOrAfterCommand(): void
+    {
+        foreach ([['--json', 'generate'], ['generate', '--json']] as $argOrder) {
+            $output = new BufferedOutput();
+            $app = new Application($output);
+
+            $exitCode = $app->run(array_merge(['hybrid-id'], $argOrder));
+
+            $this->assertSame(0, $exitCode);
+            $decoded = json_decode($output->getLines()[0], true);
+            $this->assertIsArray($decoded);
+            $this->assertArrayHasKey('ids', $decoded);
+        }
+    }
 }


### PR DESCRIPTION
## Overview
This PR modernizes the CLI tooling and addresses a long-standing technical debt issue regarding error handling, improving both developer experience and codebase maintainability. 

Closes #210
Closes #212
Closes #158

## Changes Made
### 1. Global JSON Output Flag (#210)
Added a global `--json` flag to the `hybrid-id` executable. This allows commands like `generate` and `inspect` to bypass standard formatting and emit strict JSON, making it much easier to integrate the CLI into automated shell scripts, CI/CD pipelines, or external tools.

### 2. Documented CLI Flags (#212)
Added the missing documentation for the global `--blind` flag inside `Application::commandHelp()`. Previously, this feature was only discoverable by reading the external README; it is now natively visible in the terminal output.

### 3. Exception Message Centralization (#158)
We executed the deferred implementation plan for centralizing error messages. 
**Implementation Plan Followed:**
- Created a new internal `HybridId\Exception\Messages` class.
- Replaced approximately ~40 hardcoded exception strings scattered across `ProfileRegistry`, `MockHybridIdGenerator`, `UuidConverter`, and `HybridIdGenerator`.
- Leveraged `sprintf()` for dynamic messages while porting the base templates into strict constants.
- **Zero Breaking Changes:** String fidelity was completely maintained. The PHPUnit test suite passes completely, confirming that no external assertions relying on exact exception messages were broken.

## Verification
- [x] Tested CLI `generate --json` and `inspect --json` locally.
- [x] Verified `phpstan` max level compliance.
- [x] Verified `phpunit` suite passes with 100% success rate.
