### PR TITLE
chore(ci): correct stale version comment on codecov-action pin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
         run: vendor/bin/phpunit --coverage-clover=coverage.xml --exclude-group=benchmark
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v5
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml


### PR DESCRIPTION
## What

One-line change: the version comment on the `codecov/codecov-action` pin said `# v5` while the pinned hash is actually **v7.0.0**.

```diff
-        uses: codecov/codecov-action@fb8b3582... # v5
+        uses: codecov/codecov-action@fb8b3582... # v7.0.0
```

**The hash is unchanged.** Comment only — no behaviour change.

## Why

The comment went stale in #216 (`5.4.3 -> 6.0.0`) and #251 (`6.0.0 -> 7.0.0`) did not fix it either, so it had been wrong across two majors.

Since all actions here are pinned to commit hashes, that trailing comment is the only human-readable version marker in the file. A comment that lies is worse than no comment: anyone auditing the workflow reads `v5` and believes it.

## Verification

`fb8b3582c8e4def4969c97caa2f19720cb33a72f` was confirmed against the upstream tag:

- `git/ref/tags/v7.0.0` -> annotated tag object `e53489f`
- dereferenced -> commit `fb8b3582c8e4def4969c97caa2f19720cb33a72f` ✅

## Note

`shivammathur/setup-php` still uses the major-only form (`# v2`) rather than the full version, unlike `actions/checkout` (`# v7.0.1`). Left as-is here to keep this PR to the actual defect — happy to normalise it in a follow-up.